### PR TITLE
Refactor Codex review policy sources

### DIFF
--- a/.github/codex/review.md
+++ b/.github/codex/review.md
@@ -1,7 +1,7 @@
 You are Codex performing a GitHub PR review.
 
 Review focus:
-- Follow AGENTS.md instructions.
+- Follow `docs/codex-review-policy.md` when present. Otherwise fall back to any PR review guidance included from `AGENTS.md`.
 - Use the matching milestone guide included in the prompt when the PR branch or base branch maps to one.
 - Only require the build check to pass (no other tests are required).
 - Review the PR description and the code diff directly.

--- a/.github/workflows/codex-reply.yml
+++ b/.github/workflows/codex-reply.yml
@@ -61,6 +61,8 @@ jobs:
             core.setOutput('pull_number', String(pr.number));
             core.setOutput('base_sha', pr.base?.sha || '');
             core.setOutput('head_sha', pr.head?.sha || '');
+            core.setOutput('base_ref', pr.base?.ref || '');
+            core.setOutput('head_ref', pr.head?.ref || '');
             core.setOutput('trigger_comment_id', String(triggerComment.id));
             core.setOutput('trigger_author', triggerComment.user?.login || 'unknown');
             core.setOutput('developer_response', developerResponse);
@@ -84,12 +86,15 @@ jobs:
         env:
           BASE_SHA: ${{ steps.context.outputs.base_sha }}
           HEAD_SHA: ${{ steps.context.outputs.head_sha }}
+          BASE_REF: ${{ steps.context.outputs.base_ref }}
+          HEAD_REF: ${{ steps.context.outputs.head_ref }}
           ORIGINAL_COMMENT: ${{ steps.context.outputs.original_comment }}
           DEVELOPER_RESPONSE: ${{ steps.context.outputs.developer_response }}
           THREAD_SUMMARY: ${{ steps.context.outputs.thread_summary }}
         run: |
           python3 - <<'PY'
           import os
+          from pathlib import Path
 
           prompt = """You are reviewing a developer's response to a prior Codex review comment in a PR thread.
 
@@ -124,6 +129,30 @@ jobs:
 
           with open("/tmp/codex_reply_prompt.md", "w", encoding="utf-8") as f:
               f.write(prompt)
+              repo_guidance = Path("AGENTS.md")
+              if repo_guidance.exists():
+                  f.write("\n\nRepository instructions (from HEAD):\n")
+                  f.write(repo_guidance.read_text(encoding="utf-8"))
+              review_policy = Path("docs/codex-review-policy.md")
+              if review_policy.exists():
+                  f.write("\n\nPR review policy (from HEAD):\n")
+                  f.write(review_policy.read_text(encoding="utf-8"))
+              milestone_guides = {
+                  "feature/milestone-1-benchmark": "docs/milestones/Milestone1_HostSideTestHarness.md",
+                  "feature/milestone-2-tinyframe": "docs/milestones/Milestone2_TinyFrame.md",
+                  "feature/milestone-3-crc-framing": "docs/milestones/Milestone3_LengthPrefixCRC.md",
+                  "feature/milestone-4-cdc": "docs/milestones/Milestone4_CDCWriteOptimization.md",
+              }
+              guide_path = milestone_guides.get(os.getenv("HEAD_REF", "")) or milestone_guides.get(os.getenv("BASE_REF", ""))
+              if guide_path:
+                  guide = Path(guide_path)
+                  if guide.exists():
+                      f.write(f"\n\nMatching milestone guide (from HEAD): {guide_path}\n")
+                      f.write(guide.read_text(encoding="utf-8"))
+              f.write("\n\nPR head ref:\n")
+              f.write(os.getenv("HEAD_REF", ""))
+              f.write("\n\nPR base ref:\n")
+              f.write(os.getenv("BASE_REF", ""))
               f.write("\n\nPR diff boundary:\n")
               f.write(f"git diff {os.getenv('BASE_SHA','')}...{os.getenv('HEAD_SHA','')}\n\n")
               f.write("Original codex review comment:\n")

--- a/.github/workflows/codex-reply.yml
+++ b/.github/workflows/codex-reply.yml
@@ -16,7 +16,7 @@ jobs:
   codex-reply:
     if: |
       startsWith(github.event.comment.body, '#codex-reply') &&
-      contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.comment.author_association || '')
+      contains(fromJSON('["MEMBER","OWNER","COLLABORATOR","CONTRIBUTOR"]'), github.event.comment.author_association || '')
     runs-on: ubuntu-latest
     steps:
       - name: Resolve thread context

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -168,9 +168,14 @@ jobs:
 
           cat .github/codex/review.md > /tmp/codex_prompt.md
           echo "" >> /tmp/codex_prompt.md
-          echo "AGENTS instructions (from HEAD):" >> /tmp/codex_prompt.md
+          echo "Repository instructions (from HEAD):" >> /tmp/codex_prompt.md
           cat AGENTS.md >> /tmp/codex_prompt.md
           echo "" >> /tmp/codex_prompt.md
+          if [ -f docs/codex-review-policy.md ]; then
+            echo "PR review policy (from HEAD): docs/codex-review-policy.md" >> /tmp/codex_prompt.md
+            cat docs/codex-review-policy.md >> /tmp/codex_prompt.md
+            echo "" >> /tmp/codex_prompt.md
+          fi
           echo "PR head ref: ${{ needs.resolve-pr-context.outputs.head_ref }}" >> /tmp/codex_prompt.md
           echo "PR base ref: ${{ needs.resolve-pr-context.outputs.base_ref }}" >> /tmp/codex_prompt.md
           echo "" >> /tmp/codex_prompt.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,39 +1,17 @@
-## Review guidelines
+## Repository Guidance
 
-Scope
-- One milestone per PR. If a PR mixes work from multiple milestones or adds unrelated refactors, request a split.
-- Keep changes focused on the stated deliverable for the milestone branch.
-- Small, safe fixes are fine when they are directly in support of the milestone and do not broaden scope materially.
+Build and dependencies
+- Prefer the Docker + Makefile workflow documented in `README.md`.
+- Firmware builds normally run via `make firmware`.
+- Host benchmark work normally runs via `make benchmark`.
+- Local CMake builds require `PICO_SDK_PATH` to be set.
+- Third-party dependencies under `include/` are git submodules. Keep them initialized with `git submodule update --init --recursive`.
 
-Milestone guides
-- Use the milestone guide under `docs/milestones/` that matches the PR branch or base branch when one of the following branch names appears:
-  - `feature/milestone-1-benchmark` -> `docs/milestones/Milestone1_HostSideTestHarness.md`
-  - `feature/milestone-2-tinyframe` -> `docs/milestones/Milestone2_TinyFrame.md`
-  - `feature/milestone-3-crc-framing` -> `docs/milestones/Milestone3_LengthPrefixCRC.md`
-  - `feature/milestone-4-cdc` -> `docs/milestones/Milestone4_CDCWriteOptimization.md`
-- Treat the matching milestone guide as the primary checklist for scope and expected deliverables.
-- If no milestone guide matches the PR branch or base branch, review against the PR description and the code diff directly.
+Change scope and safety
+- Keep changes focused on the task at hand. Do not widen scope with unrelated refactors or workflow churn.
+- Treat dependency wiring, Docker setup, and debug/flash flows as shared repo infrastructure. Do not change them unless the task requires it.
+- Keep third-party dependency management consistent with the repository’s submodule-based model under `include/`.
 
-Correctness
-- Confirm the PR satisfies the milestone deliverables it claims to implement.
-- Flag behavioral changes outside the stated milestone scope.
-- Ensure build, benchmark, and protocol/documentation changes remain consistent with the implementation.
-- Be explicit about unsupported commands, partial implementations, benchmark gaps, and protocol mismatches.
-- When raising a finding, prefer to also suggest a concrete fix, preferred resolution, or next verification step so the review is actionable instead of purely critical.
-
-Commit/history hygiene
-- Commits should be focused and reviewable.
-- Messages should state what changed and why.
-- If the branch is not rebased onto its base branch, request a rebase before merge.
-
-When to request changes
-- Mixed milestone scope
-- Missing or incomplete milestone deliverables
-- Unclear or unsafe behavior changes
-- Build or review workflow regressions
-- Noisy history or unclear commit intent
-
-Review style
-- Findings should be specific and technically grounded.
-- Prefer actionable review comments over purely descriptive criticism.
-- When possible, point to the likely remediation path, not just the symptom.
+PR review workflows
+- `codex-review` and `codex-reply` policy lives in `docs/codex-review-policy.md`.
+- Milestone-specific review guidance lives under `docs/milestones/`.

--- a/docs/codex-review-policy.md
+++ b/docs/codex-review-policy.md
@@ -1,0 +1,41 @@
+# Codex PR Review Policy
+
+This policy applies to PR review workflows such as `codex-review`, follow-up checks such as `codex-reply`, and local PR review helpers.
+
+## Scope
+- One milestone per PR. If a PR mixes work from multiple milestones or adds unrelated refactors, request a split.
+- Keep changes focused on the stated deliverable for the milestone branch.
+- Small, safe fixes are fine when they are directly in support of the milestone and do not broaden scope materially.
+
+## Milestone guides
+- Use the milestone guide under `docs/milestones/` that matches the PR branch or base branch when one of the following branch names appears:
+  - `feature/milestone-1-benchmark` -> `docs/milestones/Milestone1_HostSideTestHarness.md`
+  - `feature/milestone-2-tinyframe` -> `docs/milestones/Milestone2_TinyFrame.md`
+  - `feature/milestone-3-crc-framing` -> `docs/milestones/Milestone3_LengthPrefixCRC.md`
+  - `feature/milestone-4-cdc` -> `docs/milestones/Milestone4_CDCWriteOptimization.md`
+- Treat the matching milestone guide as the primary checklist for scope and expected deliverables.
+- If no milestone guide matches the PR branch or base branch, review against the PR description and the code diff directly.
+
+## Correctness
+- Confirm the PR satisfies the milestone deliverables it claims to implement.
+- Flag behavioral changes outside the stated milestone scope.
+- Ensure build, benchmark, and protocol/documentation changes remain consistent with the implementation.
+- Be explicit about unsupported commands, partial implementations, benchmark gaps, and protocol mismatches.
+- When raising a finding, prefer to also suggest a concrete fix, preferred resolution, or next verification step so the review is actionable instead of purely critical.
+
+## Commit/history hygiene
+- Commits should be focused and reviewable.
+- Messages should state what changed and why.
+- If the branch is not rebased onto its base branch, request a rebase before merge.
+
+## When to request changes
+- Mixed milestone scope
+- Missing or incomplete milestone deliverables
+- Unclear or unsafe behavior changes
+- Build or review workflow regressions
+- Noisy history or unclear commit intent
+
+## Review style
+- Findings should be specific and technically grounded.
+- Prefer actionable review comments over purely descriptive criticism.
+- When possible, point to the likely remediation path, not just the symptom.


### PR DESCRIPTION
## Summary
- move PR review-specific Codex guidance from `AGENTS.md` into `docs/codex-review-policy.md`
- update `codex-review` and `codex-reply` to read the new review-policy source and matching milestone guide
- allow `CONTRIBUTOR` to trigger `#codex-reply` so valid follow-up comments are not skipped

## Why
- keeps `AGENTS.md` scoped to repo-wide guidance instead of PR-review-only policy
- preserves the existing milestone mapping and Codex review/reply behavior with an explicit policy source
- fixes skipped `codex-reply` runs caused by contributor-associated review-thread comments