### PR TITLE
Firmware-side latency benchmark measurements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CMAKE_COLOR_MAKEFILE ON)
 # Build options
 option(USE_DOCKER "Build using Docker container" ON)
 option(USE_LOCAL "Build locally instead of Docker" OFF)
+option(LATENCY_BENCHMARK "Compile firmware in latency benchmarking mode" OFF)
 
 # Set build type if not specified
 if(NOT CMAKE_BUILD_TYPE)
@@ -77,6 +78,10 @@ target_compile_definitions(robot PUBLIC
 # MILESTONE 1: BOARD GATING
 if(BUILD_FOR_PICO)
     target_compile_definitions(robot PUBLIC BOARD_PICO)
+endif()
+
+if(LATENCY_BENCHMARK)
+    target_compile_definitions(robot PUBLIC ENABLE_LATENCY_BENCHMARK=1)
 endif()
 
 pico_enable_stdio_uart(robot 0)

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ shell:
 .PHONY: benchmark
 benchmark:
 	@echo "Building host benchmark in Docker..."
-	$(DOCKER_TEST_RUN) bash -c "cmake -S tools/benchmark -B tools/benchmark/build && cmake --build tools/benchmark/build -j$(JOBS)"
+	$(DOCKER_TEST_RUN) bash -c "cmake -S tools/benchmark -B tools/benchmark/build -DLATENCY_BENCHMARK=$(LATENCY_BENCHMARK) && cmake --build tools/benchmark/build -j$(JOBS)"
 	@echo "Running host benchmark in Docker..."
 	$(DOCKER_TEST_RUN) bash -c "./tools/benchmark/build/benchmark"
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ JOBS ?= $(shell nproc)
 DOCKER_DEBUG_CONTAINER := smartphone-robot-debug
 ARCH ?= amd64
 LOGGER ?= USB
+LATENCY_BENCHMARK ?= OFF
 
 #  MILESTONE 1: BOARD SELECTION & VALIDATION 
 BOARD ?= customPCB
@@ -74,13 +75,14 @@ help:
 	@echo "  JOBS=N                - Number of parallel build jobs (default: The number of processor cores)"
 	@echo "  ARCH=amd64|arm64        - Specify architecture for all make targets (default: amd64)"
 	@echo "  LOGGER=USB|UART         - Specify logger interface (default: USB)"
+	@echo "  LATENCY_BENCHMARK=ON|OFF     - Enable firmware latency benchmark mode (default: OFF)"
 	@echo "  Example: make flash DOCKER_USB_DEVICE=/dev/ttyACM0"
 
 # Build firmware
 .PHONY: firmware
 firmware:
 	@echo "Building firmware in Docker with $(JOBS) jobs..."
-	$(DOCKER_RUN) bash -c "rm -rf build && mkdir build && cd build && cmake .. -DLOGGER=$(LOGGER) $(BOARD_FLAGS) && make -j$(JOBS)"
+	$(DOCKER_RUN) bash -c "rm -rf build && mkdir build && cd build && cmake .. -DLOGGER=$(LOGGER) -DLATENCY_BENCHMARK=$(LATENCY_BENCHMARK) $(BOARD_FLAGS) && make -j$(JOBS)"
 
 # Name for the persistent debug container
 DEBUG_CONTAINER := smartphone-robot-debug

--- a/include/serial_comm_manager.h
+++ b/include/serial_comm_manager.h
@@ -71,12 +71,23 @@ typedef struct
     uint8_t end_marker;
 } IncomingPacketFromAndroid;
 
+#ifdef ENABLE_LATENCY_BENCHMARK
+typedef struct
+{
+    uint64_t t4_timestamp_us;
+    uint64_t t5_timestamp_us;
+} LatencyMeasurements;
+#endif
+
 typedef struct
 {
     uint8_t start_marker;
     uint8_t packet_type;
     uint16_t data_size;
     RP2040_STATE data;
+#ifdef ENABLE_LATENCY_BENCHMARK
+    LatencyMeasurements telemetry;
+#endif
     uint8_t end_marker;
 } OutgoingPacketToAndroid;
 

--- a/src/serial_comm_manager.c
+++ b/src/serial_comm_manager.c
@@ -1,6 +1,7 @@
 #include "pico/types.h"
 #include "serial_comm_manager.h"
 #include "pico/stdio.h"
+#include "pico/time.h"
 #include <string.h>
 #include <stdio.h>
 #include "robot.h"
@@ -18,7 +19,13 @@ void serial_comm_manager_init(RP2040_STATE* rp2040_state){
     incoming_packet_from_android.end_marker = END_MARKER;
     outgoing_packet_to_android.start_marker = START_MARKER;
     outgoing_packet_to_android.end_marker = END_MARKER;
-    outgoing_packet_to_android.data_size = sizeof(rp2040_state_);
+
+#if defined(ENABLE_LATENCY_BENCHMARK)
+    outgoing_packet_to_android.data_size = sizeof(RP2040_STATE) + sizeof(LatencyMeasurements);
+#else
+    outgoing_packet_to_android.data_size = sizeof(RP2040_STATE);
+#endif
+
     outgoing_log_packet_to_android.start_marker = START_MARKER;
     outgoing_log_packet_to_android.packet_type = GET_LOG;
     outgoing_log_packet_to_android.end_marker = END_MARKER;
@@ -30,6 +37,10 @@ static void reset_packet_and_send_nack(int8_t *start_idx, int8_t *end_idx, uint1
     *buffer_index = 0;
     memset(&incoming_packet_from_android, 0, sizeof(IncomingPacketFromAndroid));
     outgoing_packet_to_android.packet_type = NACK;
+#ifdef ENABLE_LATENCY_BENCHMARK
+    outgoing_packet_to_android.telemetry.t4_timestamp_us = 0;
+    outgoing_packet_to_android.telemetry.t5_timestamp_us = 0;
+#endif
     uint8_t* nack_bytes = (uint8_t*)&outgoing_packet_to_android;
     for (int j = 0; j < sizeof(outgoing_packet_to_android); j++){
         putchar(nack_bytes[j]);
@@ -73,9 +84,13 @@ void get_block() {
                 return;
 	    }
     	    i++;
-        }
+	}
 	c = getchar_timeout_us(100);
         if (c != PICO_ERROR_TIMEOUT && c == END_MARKER){
+            end_idx = buffer_index + 2;
+#ifdef ENABLE_LATENCY_BENCHMARK
+            outgoing_packet_to_android.telemetry.t4_timestamp_us = time_us_64();
+#endif
             // Calculate the length of the packet
             uint16_t packet_length = end_idx - start_idx;
             if (packet_length >= sizeof(IncomingPacketFromAndroid)) {
@@ -133,6 +148,9 @@ void handle_packet(IncomingPacketFromAndroid *packet){
             // Add STATE to response
             get_state(&rp2040_state_);
 	    outgoing_packet_to_android.data = rp2040_state_;
+#ifdef ENABLE_LATENCY_BENCHMARK
+        outgoing_packet_to_android.telemetry.t5_timestamp_us = time_us_64();
+#endif
 
 	    // Print the outgoing packet chars
             bytes = (uint8_t*)&outgoing_packet_to_android;
@@ -147,6 +165,9 @@ void handle_packet(IncomingPacketFromAndroid *packet){
             // Add STATE to response
             get_state(&rp2040_state_);
 	    outgoing_packet_to_android.data = rp2040_state_;
+#ifdef ENABLE_LATENCY_BENCHMARK
+        outgoing_packet_to_android.telemetry.t5_timestamp_us = time_us_64();
+#endif
 
 	    // Print the outgoing packet chars
             bytes = (uint8_t*)&outgoing_packet_to_android;

--- a/tools/benchmark/CMakeLists.txt
+++ b/tools/benchmark/CMakeLists.txt
@@ -5,5 +5,11 @@ project(benchmark_tool LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+option(LATENCY_BENCHMARK "Enable firmware latency benchmark response size" OFF)
+
 add_executable(benchmark main.cpp)
+
+if(LATENCY_BENCHMARK)
+    target_compile_definitions(benchmark PRIVATE LATENCY_BENCHMARK=1)
+endif()
 

--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -51,6 +51,12 @@ make benchmark
 
 ```
 
+If the firmware is already flashed with `LATENCY_BENCHMARK=ON`, run:
+
+```bash
+make benchmark LATENCY_BENCHMARK=ON
+```
+
 ## Note about `robot.c` and Hardware Gating
 
 To test locally on a standard Raspberry Pi Pico while maintaining support for the `customPCB`, proper board gating was implemented.
@@ -65,7 +71,7 @@ The tool targets the specific `SET_MOTOR_LEVEL` path for Milestone 1:
 * **Command:** `0x01` (SET_MOTOR_LEVEL)
 * **End Marker:** `0xFF`
 * **TX Packet:** 5 Bytes `[START, CMD, 0x00, 0x00, END]`
-* **RX Expected Response:** 34 Bytes (The Pico responds by packing the entire `RP2040_STATE` structure).
+* **RX Expected Response:** 34 Bytes normally, or 50 Bytes when `LATENCY_BENCHMARK=ON` (the Pico appends the `LatencyMeasurements` telemetry after `RP2040_STATE`).
 
 ## Expected Output
 

--- a/tools/benchmark/main.cpp
+++ b/tools/benchmark/main.cpp
@@ -29,7 +29,11 @@ const uint8_t END_MARKER   = 0xFF;
 const uint8_t CMD_SET_MOTOR = 0x01;
 const int BAUDRATE = B115200;
 const int TEST_ITERATIONS = 100;
+#ifdef LATENCY_BENCHMARK
+const int EXPECTED_RESPONSE_SIZE = 50;
+#else
 const int EXPECTED_RESPONSE_SIZE = 34;
+#endif
 
 class SerialPort {
 public:


### PR DESCRIPTION
## Summary
- What is in scope for this PR?

This milestone covers the firmware-side work needed to support granular round-trip time measurements for the phone-connected benchmark flow.

The merged scope contains two required tasks:

1. Capture and store the firmware-side benchmark timestamps T4 and T5 in memory.
2. Conditionally extend `OutgoingPacketToAndroid` so those benchmark measurements can be sent back to the phone in real time.

The build switch for this work is `LATENCY_BENCHMARK`.

Current measurement points for tests done via mock firmware:

| ID     | Junction Point            | Location                                             |
|:-------|:--------------------------|:-----------------------------------------------------|
| **T1** | Command Creation Start    | `SerialCommManager.setMotorLevels()`                 |
| **T2** | Writer Loop Wake-up       | `SerialCommManager.android2PiWriter` (after `wait`)  |
| **T3** | Transport Dispatch        | `UsbSerial.send(ByteArray)` (start)                  |
| **T4** | Simulator Receipt         | `MockRP2040.processPacket()` (start)                 |
| **T5** | Response Receipt at Phone | `UsbSerial.onNewData()` (start)                      |
| **T6** | Packet Queue Entry        | `UsbSerial.onCompletePacketReceived()` (end)         |
| **T7** | Manager Wake-up           | `SerialCommManager.receivePacket()` (after await)    |
| **T8** | State Applied             | `SerialCommManager.parseStatus()` (after publishers) |

New proposed measurements for the firmware-backed benchmark flow:

| ID     | Junction Point            | Location                                             |
|:-------|:--------------------------|:-----------------------------------------------------|
| **T1** | Command Creation Start    | `SerialCommManager.setMotorLevels()`                 |
| **T2** | Writer Loop Wake-up       | `SerialCommManager.android2PiWriter` (after `wait`)  |
| **T3** | Transport Dispatch        | `UsbSerial.send(ByteArray)` (start)                  |
| **T4** | Firmware Receipt          | `get_block()` (after `END_MARKER` receive)           |
| **T5** | Firmware processing time  | `handle_packet()` (before sending response)          |
| **T6** | Response Receipt at Phone | `UsbSerial.onNewData()` (start)                      |
| **T7** | Packet Queue Entry        | `UsbSerial.onCompletePacketReceived()` (end)         |
| **T8** | Manager Wake-up           | `SerialCommManager.receivePacket()` (after await)    |
| **T9** | State Applied             | `SerialCommManager.parseStatus()` (after publishers) |

Task 1 is to add conditional firmware-side timestamp collection for T4 and T5, store the latest values in memory, and update them whenever a new packet is processed.

Task 2 is to extend `OutgoingPacketToAndroid` conditionally so the firmware can deliver those benchmark measurements back to the phone as part of the normal response stream. The packet layout must remain unchanged when `LATENCY_BENCHMARK` is off.

- [x] I have read and agree to follow `docs/PR_WORKFLOW.md` for this PR.

## Branching
- Milestone base branch: `milestone/FirmwareBenchmarking`
- This PR branch: `FirmwareBenchmarking/measuring`
- [x] Branch naming follows the required convention.
- [x] Branch is rebased on the current base branch (no merge commit from "Update branch").

## Scope Declaration
- Exact slice/module in this PR:
  - `src/serial_comm_manager.c`
  - `include/serial_comm_manager.h`
  - `CMakeLists.txt`
  - `Makefile`
- Related sibling PRs/issues (remaining slices), if any:
  - #13 
