### PR TITLE
Add logging verbosity levels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,24 @@ if(NOT (LOGGER STREQUAL "USB" OR LOGGER STREQUAL "UART"))
   message(FATAL_ERROR "invalid logging interface: ${LOGGER}")
 endif()
 
+# Logging level
+set(LOG_LEVEL "INFO" CACHE STRING "Logging level")
+if(NOT (LOG_LEVEL STREQUAL "DEBUG" OR LOG_LEVEL STREQUAL "INFO" OR LOG_LEVEL STREQUAL "WARNING" OR LOG_LEVEL STREQUAL "ERROR" OR LOG_LEVEL STREQUAL "NONE"))
+  message(FATAL_ERROR "invalid logging level: ${LOG_LEVEL}")
+endif()
+
+if(LOG_LEVEL STREQUAL "DEBUG")
+  set(LOG_LEVEL_NUM 1)
+elseif(LOG_LEVEL STREQUAL "INFO")
+  set(LOG_LEVEL_NUM 2)
+elseif(LOG_LEVEL STREQUAL "WARNING")
+  set(LOG_LEVEL_NUM 3)
+elseif(LOG_LEVEL STREQUAL "ERROR")
+  set(LOG_LEVEL_NUM 4)
+elseif(LOG_LEVEL STREQUAL "NONE")
+    set(LOG_LEVEL_NUM 5)
+endif()
+
 # Enable colored output
 set(CMAKE_COLOR_MAKEFILE ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT (LOGGER STREQUAL "USB" OR LOGGER STREQUAL "UART"))
 endif()
 
 # Logging level
-set(LOG_LEVEL "INFO" CACHE STRING "Logging level")
+set(LOG_LEVEL "WARNING" CACHE STRING "Logging level")
 if(NOT (LOG_LEVEL STREQUAL "DEBUG" OR LOG_LEVEL STREQUAL "INFO" OR LOG_LEVEL STREQUAL "WARNING" OR LOG_LEVEL STREQUAL "ERROR" OR LOG_LEVEL STREQUAL "NONE"))
   message(FATAL_ERROR "invalid logging level: ${LOG_LEVEL}")
 endif()
@@ -108,6 +108,8 @@ pico_enable_stdio_usb(robot 1)
 if(LOGGER STREQUAL "UART")
     target_compile_definitions(robot PUBLIC LOGGER_UART=1)
 endif()
+
+target_compile_definitions(robot PUBLIC LOG_LEVEL=${LOG_LEVEL_NUM})
 
 if(DRV8830_SCOPE_TEST)
     target_compile_definitions(robot PUBLIC

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,20 @@ else
   DOCKER_IMAGE_TAG := $(DOCKER_IMAGE):$(DOCKER_TAG)-$(ARCH)
 endif
 
+LOG_LEVEL ?= INFO
+
+ifneq ($(LOG_LEVEL), DEBUG)
+ifneq ($(LOG_LEVEL), INFO)
+ifneq ($(LOG_LEVEL), WARNING)
+ifneq ($(LOG_LEVEL), ERROR)
+ifneq ($(LOG_LEVEL), NONE)
+$(error Invalid LOG_LEVEL value: $(LOG_LEVEL). Must be 'DEBUG|INFO|WARNING|ERROR|NONE')
+endif
+endif
+endif
+endif
+endif
+
 DOCKER_RUN := docker run --rm -it \
     --device /dev/bus/usb:/dev/bus/usb \
     -v $(shell pwd):/project \

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ else
   DOCKER_IMAGE_TAG := $(DOCKER_IMAGE):$(DOCKER_TAG)-$(ARCH)
 endif
 
-LOG_LEVEL ?= INFO
+LOG_LEVEL ?= WARNING
 
 ifneq ($(LOG_LEVEL), DEBUG)
 ifneq ($(LOG_LEVEL), INFO)
@@ -100,6 +100,7 @@ help:
 	@echo "  JOBS=N                - Number of parallel build jobs (default: The number of processor cores)"
 	@echo "  ARCH=amd64|arm64        - Specify architecture for all make targets (default: amd64)"
 	@echo "  LOGGER=USB|UART         - Specify logger interface (default: USB)"
+	@echo "  LOG_LEVEL=DEBUG|INFO|WARNING|ERROR|NONE     - Specify desired logging level (default: WARNING)"
 	@echo "  DRV8830_SCOPE_TEST=0|1 - Enable DRV8830 back/forth scope test (default: 0)"
 	@echo "  Example: make flash DOCKER_USB_DEVICE=/dev/ttyACM0"
 
@@ -107,7 +108,7 @@ help:
 .PHONY: firmware
 firmware:
 	@echo "Building firmware in Docker with $(JOBS) jobs..."
-	$(DOCKER_RUN) bash -c "rm -rf build && mkdir build && cd build && cmake .. -DLOGGER=$(LOGGER) $(BOARD_FLAGS) $(DRV8830_SCOPE_FLAGS) && make -j$(JOBS)"
+	$(DOCKER_RUN) bash -c "rm -rf build && mkdir build && cd build && cmake .. -DLOGGER=$(LOGGER) -DLOG_LEVEL=$(LOG_LEVEL) $(BOARD_FLAGS) $(DRV8830_SCOPE_FLAGS) && make -j$(JOBS)"
 
 # Name for the persistent debug container
 DEBUG_CONTAINER := smartphone-robot-debug

--- a/include/rp2040_log.h
+++ b/include/rp2040_log.h
@@ -21,8 +21,6 @@ typedef struct {
     char log_array[LOG_BUFFER_LINE_COUNT][LOG_BUFFER_CHAR_LIMIT];
     // create an array storing the variable size of each line in the log_array
     uint16_t log_array_line_size[LOG_BUFFER_LINE_COUNT];
-    // number of populated entries currently stored in the ring
-    uint16_t count;
     uint16_t head;
     uint16_t tail;
     volatile bool lock; // Added a lock variable

--- a/include/rp2040_log.h
+++ b/include/rp2040_log.h
@@ -3,6 +3,15 @@
 
 #include "pico/types.h"
 
+#define LOG_LEVEL_DEBUG 1
+#define LOG_LEVEL_INFO 2
+#define LOG_LEVEL_WARNING 3
+#define LOG_LEVEL_ERROR 4
+
+#ifndef LOG_LEVEL
+#define LOG_LEVEL LOG_LEVEL_INFO
+#endif
+
 #define LOG_BUFFER_LINE_COUNT 1028
 #define LOG_BUFFER_CHAR_LIMIT 128
 
@@ -12,17 +21,43 @@ typedef struct {
     char log_array[LOG_BUFFER_LINE_COUNT][LOG_BUFFER_CHAR_LIMIT];
     // create an array storing the variable size of each line in the log_array
     uint16_t log_array_line_size[LOG_BUFFER_LINE_COUNT];
+    // number of populated entries currently stored in the ring
+    uint16_t count;
     uint16_t head;
     uint16_t tail;
     volatile bool lock; // Added a lock variable
 }CircularBufferLog ;
 
 void rp2040_log_init();
-void rp2040_log(const char *format, ...);
+void rp2040_log(int level, const char *format, ...);
 void rp2040_log_flush();
 uint16_t rp2040_get_byte_count();
 void rp2040_orient_copy_buffer(char* output_array);
 void rp2040_log_acquire_lock();
 void rp2040_log_release_lock();
+
+#if LOG_LEVEL <= LOG_LEVEL_DEBUG
+#define rp2040_log_d(...) rp2040_log(LOG_LEVEL_DEBUG, __VA_ARGS__)
+#else
+#define rp2040_log_d(...) ((void)0)
+#endif
+
+#if LOG_LEVEL <= LOG_LEVEL_INFO
+#define rp2040_log_i(...) rp2040_log(LOG_LEVEL_INFO, __VA_ARGS__)
+#else
+#define rp2040_log_i(...) ((void)0)
+#endif
+
+#if LOG_LEVEL <= LOG_LEVEL_WARNING
+#define rp2040_log_w(...) rp2040_log(LOG_LEVEL_WARNING, __VA_ARGS__)
+#else
+#define rp2040_log_w(...) ((void)0)
+#endif
+
+#if LOG_LEVEL <= LOG_LEVEL_ERROR
+#define rp2040_log_e(...) rp2040_log(LOG_LEVEL_ERROR, __VA_ARGS__)
+#else
+#define rp2040_log_e(...) ((void)0)
+#endif
 
 #endif

--- a/src/STWLC38JRM.c
+++ b/src/STWLC38JRM.c
@@ -54,5 +54,5 @@ void STWLC38_get_ept_reasons(){
     send_buf[1] = 0x27;
     i2c_write_error_handling(i2c0, STWLC38_ADDR, send_buf, 2, true);
     i2c_read_error_handling(i2c0, STWLC38_ADDR, return_buf, 3, false);
-    rp2040_log("STWLC38 EPT Reason: 0x0127: 0x%02x, 0x0128: 0x%02x, 0x0129: 0x%02x", return_buf[0], return_buf[1], return_buf[2]);
+    rp2040_log_d("STWLC38 EPT Reason: 0x0127: 0x%02x, 0x0128: 0x%02x, 0x0129: 0x%02x", return_buf[0], return_buf[1], return_buf[2]);
 }

--- a/src/bq27742_g1.c
+++ b/src/bq27742_g1.c
@@ -69,33 +69,36 @@ uint8_t bq27742_g1_get_safety_stats(){
     bq27742_g1_read_bytes(BQ27742_G1_REG_SAFETY_STATUS, return_buf, 2);
     
     uint8_t low_byte = return_buf[0];
-    if (low_byte & (ISD_MASK | TDD_MASK | OTC_MASK | OTD_MASK | OVP_MASK | UVP_MASK)) {
-        rp2040_log_w("SafetyStats: ");
-
-        if (low_byte & ISD_MASK)
-            rp2040_log_w("Internal Short condition detected, ");
-
-        if (low_byte & TDD_MASK)
-            rp2040_log_w("Tab Disconnect condition detected, ");
-
-        if (low_byte & OTC_MASK)
-            rp2040_log_w("Overtemperature in charge condition detected, ");
-
-        if (low_byte & OTD_MASK)
-            rp2040_log_w("Overtemperature in discharge condition detected, ");
-
-        if (low_byte & OVP_MASK)
-            rp2040_log_w("Overvoltage condition detected, ");
-
-        if (low_byte & UVP_MASK)
-            rp2040_log_w("Undervoltage condition detected, ");
-        rp2040_log_w("\n");
-    } else {
-        rp2040_log_d("SafetyStats: ");
-        rp2040_log_d("No error detected in battery protection\n");
+    bool error = false;
+    rp2040_log_w("SafetyStats: ");
+    if (low_byte & ISD_MASK){
+        rp2040_log_w("Internal Short condition detected, ");
+        error = true;
     }
-
-    return low_byte;
+    if (low_byte & TDD_MASK){
+        rp2040_log_w("Tab Disconnect condition detected, ");
+        error = true;
+    }
+    if (low_byte & OTC_MASK){
+        rp2040_log_w("Overtemperature in charge condition detected, ");
+        error = true;
+    }
+    if (low_byte & OTD_MASK){
+        rp2040_log_w("Overtemperature in discharge condition detected, ");
+        error = true;
+    }
+    if (low_byte & OVP_MASK){
+        rp2040_log_w("Overvoltage condition detected, ");
+        error = true;
+    }
+    if (low_byte & UVP_MASK){
+        rp2040_log_w("Undervoltage condition detected, ");
+        error = true;
+    }
+    if (!error){
+        rp2040_log_w("No error detected in battery protection\n");
+    }
+  return low_byte;  
 }
 
 uint16_t bq27742_g1_get_temp(){
@@ -136,52 +139,58 @@ uint16_t bq27742_g1_get_flags(){
     uint16_t flags = (return_buf[1] << 8) | return_buf[0];
     bool error = false;
 
-    if (flags & (BATHI_MASK | BATLOW_MASK | CHG_INH_MASK | FC_MASK | CHG_SUS_MASK | IMAX_MASK | CHG_MASK | SOC1_MASK | SOCF_MASK | DSG_MASK)) {
-        rp2040_log_w("Tags: ");
-        if (flags & BATHI_MASK)
-            rp2040_log_w("High battery voltage condition BATHI detected, ");
-
-        if (flags & BATLOW_MASK)
-            rp2040_log_w("Low battery voltage condition BATLOW detected, ");
-
-        if (flags & CHG_INH_MASK)
-            rp2040_log_w("Temperature is < T1 Temp or > T4 Temp while charging is not active. CHG_INH detected, ");
-
-        if (flags & FC_MASK)
-            rp2040_log_w("Charge termination reached and FC Set Percent = -1. Or SOC > FC Percent is not -1. FC detected, ");
-
-        if (flags & CHG_SUS_MASK)
-            rp2040_log_w("Temp < T1 Temp or > T5 Temp while charging active. CHG_SUS detected, ");
-
-        if (flags & IMAX_MASK)
-            rp2040_log_w("Imax value has changed enough to interrupt. IMAX detected, ");
-
-        if (flags & CHG_MASK)
-            rp2040_log_w("Fast charging allowed. CHG detected, ");
-
-        if (flags & SOC1_MASK)
-            rp2040_log_w("SOC1 reached.");
-
-        if (flags & SOCF_MASK)
-            rp2040_log_w("SOCF Set Percent reached. SOCF detected, ");
-
-        if (flags & DSG_MASK)
-            rp2040_log_w("Discharging detected. DSG detected, ");
-
-        rp2040_log_w("\n");
-    } else {
-        rp2040_log_d("Tags: ");
-        rp2040_log_d("No SystemStat errors detected");
-        rp2040_log_d("\n");
+    rp2040_log_w("Tags: ");
+    if (flags & BATHI_MASK){
+        rp2040_log_w("High battery voltage condition BATHI detected, ");
+        error = true;
     }
-
+    if (flags & BATLOW_MASK){
+        rp2040_log_w("Low battery voltage condition BATLOW detected, ");
+        error = true;
+    }
+    if (flags & CHG_INH_MASK){
+        rp2040_log_w("Temperature is < T1 Temp or > T4 Temp while charging is not active. CHG_INH detected, ");
+        error = true;
+    }
+    if (flags & FC_MASK){
+        rp2040_log_w("Charge termination reached and FC Set Percent = -1. Or SOC > FC Percent is not -1. FC detected, ");
+        error = true;
+    }
+    if (flags & CHG_SUS_MASK){
+        rp2040_log_w("Temp < T1 Temp or > T5 Temp while charging active. CHG_SUS detected, ");
+        error = true;
+    }
+    if (flags & IMAX_MASK){
+        rp2040_log_w("Imax value has changed enough to interrupt. IMAX detected, ");
+        error = true;
+    }
+    if (flags & CHG_MASK){
+        rp2040_log_w("Fast charging allowed. CHG detected, ");
+        error = true;
+    }
+    if (flags & SOC1_MASK){
+        rp2040_log_w("SOC1 reached.");
+        error = true;
+    }
+    if (flags & SOCF_MASK){  
+        rp2040_log_w("SOCF Set Percent reached. SOCF detected, ");
+        error = true;
+    }
+    if (flags & DSG_MASK){
+        rp2040_log_w("Discharging detected. DSG detected, ");
+        error = true;
+    }
+    if (!error){
+        rp2040_log_w("No SystemStat errors detected");
+    }
+    rp2040_log_w("\n");
     return flags;
 }
 
 void bq27742_g1_init(uint gpio_interrupt) {
     _gpio_interrupt = gpio_interrupt;
 
-    rp2040_log("bq27742_g1 init started\n");
+    rp2040_log_d("bq27742_g1 init started\n");
     bq27742_g1_clear_shutdown();
     bq27742_g1_configure_host_interrupts();
 
@@ -191,10 +200,10 @@ void bq27742_g1_init(uint gpio_interrupt) {
     gpio_disable_pulls(_gpio_interrupt);
     gpio_set_irq_enabled(_gpio_interrupt, bq27742_g1_irq_mask, true);
     if (!gpio_get(_gpio_interrupt)){
-        rp2040_log("BQ27742-G1 RC2_3V3 already asserted on GPIO%d\n", _gpio_interrupt);
+        rp2040_log_w("BQ27742-G1 RC2_3V3 already asserted on GPIO%d\n", _gpio_interrupt);
         bq27742_g1_queue_parse_interrupt();
     }
-    rp2040_log("bq27742_g1 init finished\n");
+    rp2040_log_d("bq27742_g1 init finished\n");
     // uint8_t buf[2];
 
     // ToDo Implement Key Daya Flash Parameters somehow.
@@ -249,46 +258,46 @@ static int32_t bq27742_g1_parse_interrupt_vals(int32_t unused){
 
     uint16_t flags = (flags_buf[1] << 8) | flags_buf[0];
     uint16_t safety = (safety_buf[1] << 8) | safety_buf[0];
-    rp2040_log("BQ27742-G1 interrupt: GPIO%d=%d Flags=0x%04x SafetyStatus=0x%04x\n",
+    rp2040_log_i("BQ27742-G1 interrupt: GPIO%d=%d Flags=0x%04x SafetyStatus=0x%04x\n",
                _gpio_interrupt,
                gpio_get(_gpio_interrupt),
                flags,
                safety);
 
     if (flags & SOC1_MASK){
-        rp2040_log("BQ27742-G1 interrupt: SOC1 set\n");
+        rp2040_log_w("BQ27742-G1 interrupt: SOC1 set\n");
     }
     if (flags & BATHI_MASK){
-        rp2040_log("BQ27742-G1 interrupt: BATHI set\n");
+        rp2040_log_w("BQ27742-G1 interrupt: BATHI set\n");
     }
     if (flags & BATLOW_MASK){
-        rp2040_log("BQ27742-G1 interrupt: BATLOW set\n");
+        rp2040_log_w("BQ27742-G1 interrupt: BATLOW set\n");
     }
     if (flags & IMAX_MASK){
-        rp2040_log("BQ27742-G1 interrupt: IMAX set, clearing latched interrupt\n");
+        rp2040_log_w("BQ27742-G1 interrupt: IMAX set, clearing latched interrupt\n");
         bq27742_g1_control(BQ27742_G1_CONTROL_IMAX_INT_CLEAR);
     }
     if (safety & ISD_MASK){
-        rp2040_log("BQ27742-G1 interrupt: ISD set\n");
+        rp2040_log_w("BQ27742-G1 interrupt: ISD set\n");
     }
     if (safety & TDD_MASK){
-        rp2040_log("BQ27742-G1 interrupt: TDD set\n");
+        rp2040_log_w("BQ27742-G1 interrupt: TDD set\n");
     }
     if (safety & OTC_MASK){
-        rp2040_log("BQ27742-G1 interrupt: OTC set\n");
+        rp2040_log_w("BQ27742-G1 interrupt: OTC set\n");
     }
     if (safety & OTD_MASK){
-        rp2040_log("BQ27742-G1 interrupt: OTD set\n");
+        rp2040_log_w("BQ27742-G1 interrupt: OTD set\n");
     }
     if (safety & OVP_MASK){
-        rp2040_log("BQ27742-G1 interrupt: OVP set\n");
+        rp2040_log_w("BQ27742-G1 interrupt: OVP set\n");
     }
     if (safety & UVP_MASK){
-        rp2040_log("BQ27742-G1 interrupt: UVP set\n");
+        rp2040_log_w("BQ27742-G1 interrupt: UVP set\n");
     }
     if ((flags & (SOC1_MASK | BATHI_MASK | BATLOW_MASK | IMAX_MASK)) == 0 &&
         (safety & (ISD_MASK | TDD_MASK | OTC_MASK | OTD_MASK | OVP_MASK | UVP_MASK)) == 0){
-        rp2040_log("BQ27742-G1 interrupt: no enabled status bits currently set\n");
+        rp2040_log_d("BQ27742-G1 interrupt: no enabled status bits currently set\n");
     }
 
     if (gpio_get(_gpio_interrupt)){
@@ -305,13 +314,13 @@ static void bq27742_g1_rearm_assert_irq(){
 
 static void bq27742_g1_configure_host_interrupts(){
     uint16_t pack_config = bq27742_g1_get_pack_configuration();
-    rp2040_log("BQ27742-G1 PackConfiguration before RC2 init: 0x%04x\n", pack_config);
+    rp2040_log_i("BQ27742-G1 PackConfiguration before RC2 init: 0x%04x\n", pack_config);
 
     uint8_t block_data[BQ27742_G1_DF_BLOCK_LEN];
     if (!bq27742_g1_read_data_flash_block(BQ27742_G1_DF_SUBCLASS_REGISTERS,
                                           BQ27742_G1_DF_BLOCK_REGISTERS,
                                           block_data)){
-        rp2040_log("ERROR: BQ27742-G1 could not read data flash for RC2 init\n");
+        rp2040_log_e("ERROR: BQ27742-G1 could not read data flash for RC2 init\n");
         return;
     }
 
@@ -327,7 +336,7 @@ static void bq27742_g1_configure_host_interrupts(){
         pack_config_low_index = BQ27742_G1_DF_PACK_CONFIG_OFFSET;
         pack_config_high_index = BQ27742_G1_DF_PACK_CONFIG_OFFSET + 1;
     } else if (data_flash_pack_config_be != pack_config){
-        rp2040_log("BQ27742-G1 PackConfiguration byte order not verified by command read; using TRM order\n");
+        rp2040_log_w("BQ27742-G1 PackConfiguration byte order not verified by command read; using TRM order\n");
     }
 
     uint16_t old_pack_config =
@@ -342,7 +351,7 @@ static void bq27742_g1_configure_host_interrupts(){
         old_pack_config_c & ~BQ27742_G1_PACK_CONFIG_C_BTP_EN_MASK;
 
     if (old_pack_config == new_pack_config && old_pack_config_c == new_pack_config_c){
-        rp2040_log("BQ27742-G1 RC2 host interrupts already configured\n");
+        rp2040_log_i("BQ27742-G1 RC2 host interrupts already configured\n");
         return;
     }
 
@@ -359,7 +368,7 @@ static void bq27742_g1_configure_host_interrupts(){
     if (!bq27742_g1_read_data_flash_block(BQ27742_G1_DF_SUBCLASS_REGISTERS,
                                           BQ27742_G1_DF_BLOCK_REGISTERS,
                                           verify_block)){
-        rp2040_log("ERROR: BQ27742-G1 could not verify RC2 data flash write\n");
+        rp2040_log_e("ERROR: BQ27742-G1 could not verify RC2 data flash write\n");
         return;
     }
 
@@ -367,7 +376,7 @@ static void bq27742_g1_configure_host_interrupts(){
         (verify_block[pack_config_high_index] << 8) | verify_block[pack_config_low_index];
     uint8_t verify_pack_config_c = verify_block[BQ27742_G1_DF_PACK_CONFIG_C_OFFSET];
     if (verify_pack_config != new_pack_config || verify_pack_config_c != new_pack_config_c){
-        rp2040_log("ERROR: BQ27742-G1 RC2 data flash write did not verify. PackConfig=0x%04x expected=0x%04x PackConfigC=0x%02x expected=0x%02x\n",
+        rp2040_log_e("ERROR: BQ27742-G1 RC2 data flash write did not verify. PackConfig=0x%04x expected=0x%04x PackConfigC=0x%02x expected=0x%02x\n",
                    verify_pack_config,
                    new_pack_config,
                    verify_pack_config_c,
@@ -375,7 +384,7 @@ static void bq27742_g1_configure_host_interrupts(){
         return;
     }
 
-    rp2040_log("BQ27742-G1 RC2 host interrupts configured. PackConfiguration 0x%04x -> 0x%04x, PackConfigC 0x%02x -> 0x%02x\n",
+    rp2040_log_i("BQ27742-G1 RC2 host interrupts configured. PackConfiguration 0x%04x -> 0x%04x, PackConfigC 0x%02x -> 0x%02x\n",
                old_pack_config,
                new_pack_config,
                old_pack_config_c,
@@ -399,7 +408,7 @@ static bool bq27742_g1_read_data_flash_block(uint8_t subclass, uint8_t block, ui
     bq27742_g1_read_bytes(BQ27742_G1_REG_BLOCK_DATA_CHECKSUM, &checksum, 1);
     uint8_t calculated_checksum = bq27742_g1_data_flash_checksum(block_data);
     if (checksum != calculated_checksum){
-        rp2040_log("ERROR: BQ27742-G1 data flash checksum mismatch read=0x%02x calculated=0x%02x\n",
+        rp2040_log_e("ERROR: BQ27742-G1 data flash checksum mismatch read=0x%02x calculated=0x%02x\n",
                    checksum,
                    calculated_checksum);
         return false;

--- a/src/bq27742_g1.c
+++ b/src/bq27742_g1.c
@@ -59,7 +59,7 @@ uint16_t bq27742_g1_get_voltage(){
     bq27742_g1_read_bytes(0x08, return_buf, 2);
 
     voltage = (return_buf[1] << 8) | return_buf[0];
-    rp2040_log("Voltage: %d\n", (int) voltage);
+    rp2040_log_d("Voltage: %d\n", (int) voltage);
     return voltage;
 }
 
@@ -69,36 +69,33 @@ uint8_t bq27742_g1_get_safety_stats(){
     bq27742_g1_read_bytes(BQ27742_G1_REG_SAFETY_STATUS, return_buf, 2);
     
     uint8_t low_byte = return_buf[0];
-    bool error = false;
-    rp2040_log("SafetyStats: ");
-    if (low_byte & ISD_MASK){
-        rp2040_log("Internal Short condition detected, ");
-        error = true;
+    if (low_byte & (ISD_MASK | TDD_MASK | OTC_MASK | OTD_MASK | OVP_MASK | UVP_MASK)) {
+        rp2040_log_w("SafetyStats: ");
+
+        if (low_byte & ISD_MASK)
+            rp2040_log_w("Internal Short condition detected, ");
+
+        if (low_byte & TDD_MASK)
+            rp2040_log_w("Tab Disconnect condition detected, ");
+
+        if (low_byte & OTC_MASK)
+            rp2040_log_w("Overtemperature in charge condition detected, ");
+
+        if (low_byte & OTD_MASK)
+            rp2040_log_w("Overtemperature in discharge condition detected, ");
+
+        if (low_byte & OVP_MASK)
+            rp2040_log_w("Overvoltage condition detected, ");
+
+        if (low_byte & UVP_MASK)
+            rp2040_log_w("Undervoltage condition detected, ");
+        rp2040_log_w("\n");
+    } else {
+        rp2040_log_d("SafetyStats: ");
+        rp2040_log_d("No error detected in battery protection\n");
     }
-    if (low_byte & TDD_MASK){
-        rp2040_log("Tab Disconnect condition detected, ");
-        error = true;
-    }
-    if (low_byte & OTC_MASK){
-        rp2040_log("Overtemperature in charge condition detected, ");
-        error = true;
-    }
-    if (low_byte & OTD_MASK){
-        rp2040_log("Overtemperature in discharge condition detected, ");
-        error = true;
-    }
-    if (low_byte & OVP_MASK){
-        rp2040_log("Overvoltage condition detected, ");
-        error = true;
-    }
-    if (low_byte & UVP_MASK){
-        rp2040_log("Undervoltage condition detected, ");
-        error = true;
-    }
-    if (!error){
-        rp2040_log("No error detected in battery protection\n");
-    }
-  return low_byte;  
+
+    return low_byte;
 }
 
 uint16_t bq27742_g1_get_temp(){
@@ -114,7 +111,7 @@ uint16_t bq27742_g1_get_temp(){
     temperature_ = (temperature_ - 2731.5);
     temperature_ = temperature_ / 10.0;
     temperature = (uint16_t)temperature;
-    rp2040_log("Temperature: %d\n", (int)temperature);
+    rp2040_log_d("Temperature: %d\n", (int)temperature);
     return temperature; 
 }
 
@@ -124,9 +121,9 @@ uint8_t bq27742_g1_get_soh(){
     memset(send_buf, 0, sizeof send_buf);
     bq27742_g1_read_bytes(0x2e, return_buf, 2);
 
-    rp2040_log("SOH: 0x2e=%02x, 0x2f=%02x\n", return_buf[0], return_buf[1]);
+    rp2040_log_d("SOH: 0x2e=%02x, 0x2f=%02x\n", return_buf[0], return_buf[1]);
     //float soh = (float)return_buf[0] / 100;
-    rp2040_log("SOH: %02f\n", soh);
+    rp2040_log_d("SOH: %02f\n", soh);
     // Note in the user guide Section 4.1.24 the range of values is only from 0x00 to 0x64
     return return_buf[0];
 }
@@ -139,51 +136,45 @@ uint16_t bq27742_g1_get_flags(){
     uint16_t flags = (return_buf[1] << 8) | return_buf[0];
     bool error = false;
 
-    rp2040_log("Tags: ");
-    if (flags & BATHI_MASK){
-        rp2040_log("High battery voltage condition BATHI detected, ");
-        error = true;
+    if (flags & (BATHI_MASK | BATLOW_MASK | CHG_INH_MASK | FC_MASK | CHG_SUS_MASK | IMAX_MASK | CHG_MASK | SOC1_MASK | SOCF_MASK | DSG_MASK)) {
+        rp2040_log_w("Tags: ");
+        if (flags & BATHI_MASK)
+            rp2040_log_w("High battery voltage condition BATHI detected, ");
+
+        if (flags & BATLOW_MASK)
+            rp2040_log_w("Low battery voltage condition BATLOW detected, ");
+
+        if (flags & CHG_INH_MASK)
+            rp2040_log_w("Temperature is < T1 Temp or > T4 Temp while charging is not active. CHG_INH detected, ");
+
+        if (flags & FC_MASK)
+            rp2040_log_w("Charge termination reached and FC Set Percent = -1. Or SOC > FC Percent is not -1. FC detected, ");
+
+        if (flags & CHG_SUS_MASK)
+            rp2040_log_w("Temp < T1 Temp or > T5 Temp while charging active. CHG_SUS detected, ");
+
+        if (flags & IMAX_MASK)
+            rp2040_log_w("Imax value has changed enough to interrupt. IMAX detected, ");
+
+        if (flags & CHG_MASK)
+            rp2040_log_w("Fast charging allowed. CHG detected, ");
+
+        if (flags & SOC1_MASK)
+            rp2040_log_w("SOC1 reached.");
+
+        if (flags & SOCF_MASK)
+            rp2040_log_w("SOCF Set Percent reached. SOCF detected, ");
+
+        if (flags & DSG_MASK)
+            rp2040_log_w("Discharging detected. DSG detected, ");
+
+        rp2040_log_w("\n");
+    } else {
+        rp2040_log_d("Tags: ");
+        rp2040_log_d("No SystemStat errors detected");
+        rp2040_log_d("\n");
     }
-    if (flags & BATLOW_MASK){
-        rp2040_log("Low battery voltage condition BATLOW detected, ");
-        error = true;
-    }
-    if (flags & CHG_INH_MASK){
-        rp2040_log("Temperature is < T1 Temp or > T4 Temp while charging is not active. CHG_INH detected, ");
-        error = true;
-    }
-    if (flags & FC_MASK){
-        rp2040_log("Charge termination reached and FC Set Percent = -1. Or SOC > FC Percent is not -1. FC detected, ");
-        error = true;
-    }
-    if (flags & CHG_SUS_MASK){
-        rp2040_log("Temp < T1 Temp or > T5 Temp while charging active. CHG_SUS detected, ");
-        error = true;
-    }
-    if (flags & IMAX_MASK){
-        rp2040_log("Imax value has changed enough to interrupt. IMAX detected, ");
-        error = true;
-    }
-    if (flags & CHG_MASK){
-        rp2040_log("Fast charging allowed. CHG detected, ");
-        error = true;
-    }
-    if (flags & SOC1_MASK){
-        rp2040_log("SOC1 reached.");
-        error = true;
-    }
-    if (flags & SOCF_MASK){  
-        rp2040_log("SOCF Set Percent reached. SOCF detected, ");
-        error = true;
-    }
-    if (flags & DSG_MASK){
-        rp2040_log("Discharging detected. DSG detected, ");
-        error = true;
-    }
-    if (!error){
-        rp2040_log("No SystemStat errors detected");
-    }
-    rp2040_log("\n");
+
     return flags;
 }
 
@@ -476,17 +467,17 @@ static void bq27742_g1_control(uint16_t subcommand_code){
 
 static void bq27742_g1_set_shutdown(){
     bq27742_g1_control(0x0013); 
-    rp2040_log("Shutting Down bq27742_g1\n");
+    rp2040_log_d("Shutting Down bq27742_g1\n");
 }
 
 static void bq27742_g1_clear_shutdown(){
     bq27742_g1_control(0x0014); 
-    rp2040_log("Clearing Shutdown on bq27742_g1\n");
+    rp2040_log_d("Clearing Shutdown on bq27742_g1\n");
 }
 
 void bq27742_g1_fw_version_check(){
     bq27742_g1_control(0x0002); // Read FW Version
-    rp2040_log("FW Version: 0x%02x%02x\n", return_buf[1], return_buf[0]);
+    rp2040_log_i("FW Version: 0x%02x%02x\n", return_buf[1], return_buf[0]);
 }
 
 void bq27742_g1_shutdown(){

--- a/src/bq27742_g1.c
+++ b/src/bq27742_g1.c
@@ -70,7 +70,6 @@ uint8_t bq27742_g1_get_safety_stats(){
     
     uint8_t low_byte = return_buf[0];
     bool error = false;
-    rp2040_log_w("SafetyStats: ");
     if (low_byte & ISD_MASK){
         rp2040_log_w("Internal Short condition detected, ");
         error = true;
@@ -96,7 +95,7 @@ uint8_t bq27742_g1_get_safety_stats(){
         error = true;
     }
     if (!error){
-        rp2040_log_w("No error detected in battery protection\n");
+        rp2040_log_d("No error detected in battery protection\n");
     }
   return low_byte;  
 }
@@ -139,7 +138,6 @@ uint16_t bq27742_g1_get_flags(){
     uint16_t flags = (return_buf[1] << 8) | return_buf[0];
     bool error = false;
 
-    rp2040_log_w("Tags: ");
     if (flags & BATHI_MASK){
         rp2040_log_w("High battery voltage condition BATHI detected, ");
         error = true;
@@ -181,9 +179,8 @@ uint16_t bq27742_g1_get_flags(){
         error = true;
     }
     if (!error){
-        rp2040_log_w("No SystemStat errors detected");
+        rp2040_log_d("No SystemStat errors detected");
     }
-    rp2040_log_w("\n");
     return flags;
 }
 

--- a/src/drv8830.c
+++ b/src/drv8830.c
@@ -76,7 +76,7 @@ int32_t drv8830_fault_handler(int32_t gpio){
     }
 
     if (addr == 0){
-	rp2040_log("Error: invalid motor fault\n");
+	rp2040_log_w("Error: invalid motor fault\n");
 	return -1;
     }else{
         i2c_write_error_handling(i2c, addr, &reg, 1, true);
@@ -116,7 +116,7 @@ int32_t drv8830_fault_handler(int32_t gpio){
 }
 
 void drv8830_init(uint gpio_fault1, uint gpio_fault2) {
-    rp2040_log("DRV8830 init\n");
+    rp2040_log_i("DRV8830 init\n");
     _gpio_fault1 = gpio_fault1;
     _gpio_fault2 = gpio_fault2;
     gpio_init(gpio_fault1);
@@ -133,7 +133,7 @@ void drv8830_init(uint gpio_fault1, uint gpio_fault2) {
 
     set_voltage(MOTOR_LEFT, 0);
     set_voltage(MOTOR_RIGHT, 0);
-    rp2040_log("DRV8830 init complete\n");
+    rp2040_log_i("DRV8830 init complete\n");
 }
 
 /*
@@ -222,36 +222,36 @@ static void drv8830_clear_faults(){
         i2c_read_error_handling(i2c, addr[i], &fault_value, 1, false);
 	// If the first bit is not 0, then the fault has not been cleared.
         if ((fault_value & 1) != 0){
-            rp2040_log("ERROR: Motor %d cannot clear faults. Exiting.\n", i);
+            rp2040_log_e("ERROR: Motor %d cannot clear faults. Exiting.\n", i);
             assert(false);
         }
     }
 }
 
 void test_drv8830_get_faults(){
-    rp2040_log("test_drv8830_get_faults starting...\n");
+    rp2040_log_i("test_drv8830_get_faults starting...\n");
     // This already does what a test would otherwise do. 
     drv8830_clear_faults();
-    rp2040_log("test_drv8830_get_faults: PASSED.\n");
+    rp2040_log_i("test_drv8830_get_faults: PASSED.\n");
 }
 
 void test_drv8830_interrupt(){
-    rp2040_log("test_drv8830_interrupt starting...\n");
+    rp2040_log_i("test_drv8830_interrupt starting...\n");
     test_drv8830_started = true;
-    rp2040_log("test_drv8830_interrupt: prior to driving low GPIO%d. Current Value:%d\n", _gpio_fault1, gpio_get(_gpio_fault1));
+    rp2040_log_i("test_drv8830_interrupt: prior to driving low GPIO%d. Current Value:%d\n", _gpio_fault1, gpio_get(_gpio_fault1));
     gpio_set_dir(_gpio_fault1, GPIO_OUT);
     if (gpio_get(_gpio_fault1) != 0){
-	rp2040_log("ERROR: test_drv8830_interrupt: GPIO%d was not driven low. Current Value:%d\n", _gpio_fault1, gpio_get(_gpio_fault1));
+	rp2040_log_e("ERROR: test_drv8830_interrupt: GPIO%d was not driven low. Current Value:%d\n", _gpio_fault1, gpio_get(_gpio_fault1));
 	assert(false);
     }
-    rp2040_log("test_drv8830_interrupt: after driving low GPIO%d. Current Value:%d\n", _gpio_fault1, gpio_get(_gpio_fault1));
+    rp2040_log_i("test_drv8830_interrupt: after driving low GPIO%d. Current Value:%d\n", _gpio_fault1, gpio_get(_gpio_fault1));
     uint32_t i = 0;
     while (!test_drv8830_completed){
         sleep_ms(10);
 	tight_loop_contents();
 	i++;
 	if (i > 1000){
-	    rp2040_log("ERROR: test_drv8830_interrupt timed out\n");
+	    rp2040_log_e("ERROR: test_drv8830_interrupt timed out\n");
 	    assert(false);
 	}
     }
@@ -259,7 +259,7 @@ void test_drv8830_interrupt(){
     gpio_pull_up(_gpio_fault1);
     test_drv8830_started = false;
     test_drv8830_completed = false;
-    rp2040_log("test_drv8830_interrupt: Encoder 1 PASSED after %" PRIu32 " milliseconds.\n", i*10);
+    rp2040_log_i("test_drv8830_interrupt: Encoder 1 PASSED after %" PRIu32 " milliseconds.\n", i*10);
     test_drv8830_started = true;
     gpio_set_dir(_gpio_fault2, GPIO_OUT);
     while (!test_drv8830_completed){
@@ -267,14 +267,14 @@ void test_drv8830_interrupt(){
 	tight_loop_contents();
 	i++;
 	if (i > 1000){
-	    rp2040_log("ERROR: test_drv8830_interrupt timed out\n");
+	    rp2040_log_e("ERROR: test_drv8830_interrupt timed out\n");
 	    assert(false);
 	}
     }
     gpio_set_dir(_gpio_fault2, GPIO_IN);
     gpio_pull_up(_gpio_fault2);
     test_drv8830_started = false;
-    rp2040_log("test_drv8830_interrupt: Encoder 2 PASSED after %" PRIu32 " milliseconds.\n", i*10);
+    rp2040_log_i("test_drv8830_interrupt: Encoder 2 PASSED after %" PRIu32 " milliseconds.\n", i*10);
 }
 
 static int32_t drv8830_test_response(){

--- a/src/drv8830.c
+++ b/src/drv8830.c
@@ -85,7 +85,7 @@ int32_t drv8830_fault_handler(int32_t gpio){
         bool nonfault_status_irq = !active_fault;
 #ifdef DRV8830_SCOPE_TEST
         uint32_t now_ms = to_ms_since_boot(get_absolute_time());
-        rp2040_log(
+        rp2040_log_d(
             "DRV8830_SCOPE_TEST fault context t_ms=%" PRIu32 " motor=%s active_fault=%d nonfault_status_irq=%d\n",
             now_ms,
             motor,
@@ -102,14 +102,14 @@ int32_t drv8830_fault_handler(int32_t gpio){
 #endif
             return 0;
         }
-        rp2040_log("%s motor fault\n", motor);
+        rp2040_log_w("%s motor fault\n", motor);
 #ifdef DRV8830_SCOPE_TEST
         i2c_write_error_handling(i2c, addr, clear_buf, 2, false);
         i2c_write_error_handling(i2c, addr, &reg, 1, true);
         i2c_read_error_handling(i2c, addr, &fault_values_after_clear, 1, false);
         drv8830_log_fault_bits("post_clear", motor, fault_values_after_clear);
 #else
-        rp2040_log("Fault values for Motor %s: 0x%x\n", motor, fault_values);
+        rp2040_log_w("Fault values for Motor %s: 0x%x\n", motor, fault_values);
 #endif
 	return 0;
     }
@@ -288,7 +288,7 @@ void drv8830_scope_test_run(){
     const uint8_t reverse_control = ((uint8_t)DRV8830_SCOPE_TEST_CONTROL & 0xFC) | (1 << DRV8830_IN1_BIT);
     const uint8_t off_control = 0;
 
-    rp2040_log("DRV8830_SCOPE_TEST START repeat=%d control=0x%02x forward=0x%02x reverse=0x%02x dwell_ms=%d off_ms=%d\n",
+    rp2040_log_i("DRV8830_SCOPE_TEST START repeat=%d control=0x%02x forward=0x%02x reverse=0x%02x dwell_ms=%d off_ms=%d\n",
         DRV8830_SCOPE_TEST_REPEAT,
         (uint8_t)DRV8830_SCOPE_TEST_CONTROL,
         forward_control,
@@ -301,26 +301,26 @@ void drv8830_scope_test_run(){
     sleep_ms(DRV8830_SCOPE_TEST_OFF_MS);
 
     for (uint32_t i = 0; i < DRV8830_SCOPE_TEST_REPEAT; i++){
-        rp2040_log("DRV8830_SCOPE_TEST phase=%" PRIu32 " direction=forward t_ms=%" PRIu32 "\n", i + 1, to_ms_since_boot(get_absolute_time()));
+        rp2040_log_i("DRV8830_SCOPE_TEST phase=%" PRIu32 " direction=forward t_ms=%" PRIu32 "\n", i + 1, to_ms_since_boot(get_absolute_time()));
         drv8830_scope_queue_controls(forward_control, forward_control);
         sleep_ms(DRV8830_SCOPE_TEST_DWELL_MS);
 
-        rp2040_log("DRV8830_SCOPE_TEST phase=%" PRIu32 " direction=off_after_forward t_ms=%" PRIu32 "\n", i + 1, to_ms_since_boot(get_absolute_time()));
+        rp2040_log_i("DRV8830_SCOPE_TEST phase=%" PRIu32 " direction=off_after_forward t_ms=%" PRIu32 "\n", i + 1, to_ms_since_boot(get_absolute_time()));
         drv8830_scope_queue_controls(off_control, off_control);
         sleep_ms(DRV8830_SCOPE_TEST_OFF_MS);
 
-        rp2040_log("DRV8830_SCOPE_TEST phase=%" PRIu32 " direction=reverse t_ms=%" PRIu32 "\n", i + 1, to_ms_since_boot(get_absolute_time()));
+        rp2040_log_i("DRV8830_SCOPE_TEST phase=%" PRIu32 " direction=reverse t_ms=%" PRIu32 "\n", i + 1, to_ms_since_boot(get_absolute_time()));
         drv8830_scope_queue_controls(reverse_control, reverse_control);
         sleep_ms(DRV8830_SCOPE_TEST_DWELL_MS);
 
-        rp2040_log("DRV8830_SCOPE_TEST phase=%" PRIu32 " direction=off_after_reverse t_ms=%" PRIu32 "\n", i + 1, to_ms_since_boot(get_absolute_time()));
+        rp2040_log_i("DRV8830_SCOPE_TEST phase=%" PRIu32 " direction=off_after_reverse t_ms=%" PRIu32 "\n", i + 1, to_ms_since_boot(get_absolute_time()));
         drv8830_scope_queue_controls(off_control, off_control);
         sleep_ms(DRV8830_SCOPE_TEST_OFF_MS);
     }
 
     drv8830_scope_queue_controls(off_control, off_control);
     sleep_ms(50);
-    rp2040_log("DRV8830_SCOPE_TEST END motors=off t_ms=%" PRIu32 "\n", to_ms_since_boot(get_absolute_time()));
+    rp2040_log_i("DRV8830_SCOPE_TEST END motors=off t_ms=%" PRIu32 "\n", to_ms_since_boot(get_absolute_time()));
 #endif
 }
 
@@ -340,7 +340,7 @@ static int32_t drv8830_scope_set_controls(int32_t packed_controls){
 }
 
 static void drv8830_log_fault_bits(const char *prefix, const char *motor, uint8_t faults){
-    rp2040_log(
+    rp2040_log_i(
         "DRV8830_SCOPE_TEST fault_%s t_ms=%" PRIu32 " motor=%s raw=0x%02x ILIMIT=%d OTS=%d UVLO=%d OCP=%d FAULT=%d\n",
         prefix,
         to_ms_since_boot(get_absolute_time()),

--- a/src/max77958.c
+++ b/src/max77958.c
@@ -324,7 +324,7 @@ static int opcode_write(uint8_t *buf){
     // so you may send wrong data if you don't directly specify them for ALL registers. Note the defaults are NOT always 0x00,
     // so you should send all values everytime. What a pain...
     if (buf[0] != 0x21){
-	rp2040_log_w("ERROR: buffer should always start with the 0x21 register");
+	rp2040_log_e("ERROR: buffer should always start with the 0x21 register");
     }
 
     i2c_write_error_handling(i2c0, MAX77958_SLAVE_P1, buf, sizeof(send_buf), false);
@@ -384,7 +384,7 @@ void test_max77958_status_block_read_all(void)
         uint8_t val = max77958_read_register(regs[i].reg);
 
         if (val != regs[i].expected)
-            rp2040_log_w("test_max77958_status_block_read_all ERROR: %s expected 0b" BYTE_TO_BINARY_PATTERN ", got 0b" BYTE_TO_BINARY_PATTERN "\n",
+            rp2040_log_e("test_max77958_status_block_read_all ERROR: %s expected 0b" BYTE_TO_BINARY_PATTERN ", got 0b" BYTE_TO_BINARY_PATTERN "\n",
                        regs[i].name, BYTE_TO_BINARY(regs[i].expected), BYTE_TO_BINARY(val));
         else
             rp2040_log_i("test_max77958_status_block_read_all PASSED: %s matches reset value 0b" BYTE_TO_BINARY_PATTERN "\n",
@@ -402,10 +402,10 @@ void test_max77958_get_id(){
     i2c_write_error_handling(i2c0, MAX77958_SLAVE_P1, send_buf, 1, true);
     i2c_read_error_handling(i2c0, MAX77958_SLAVE_P1, return_buf, 2, false);
     if (return_buf[0] != 0x58){
-	rp2040_log_w("test_max77958_get_id ERROR: DEVICE_ID should be 0x58");
+	rp2040_log_e("test_max77958_get_id ERROR: DEVICE_ID should be 0x58");
     }
     if (return_buf[1] != 0x02){
-	rp2040_log_w("test_max77958_get_id ERROR: DEVICE_REV should be 0x02");
+	rp2040_log_e("test_max77958_get_id ERROR: DEVICE_REV should be 0x02");
     }
     rp2040_log_i("test_max77958_get_id PASSED: DEVICE_ID = %x\n", return_buf[0]);
     rp2040_log_i("test_max77958_get_id PASSED: DEVICE_REV = %x\n", return_buf[1]);
@@ -428,14 +428,14 @@ void test_max77958_bc_ctrl1_read(){
 	sleep_ms(100);
 	i++;
 	if (i > 10){
-	    rp2040_log_w("test_max77958_bc_ctrl1_read ERROR: Timed out waiting for GPIO to finish\n");
+	    rp2040_log_e("test_max77958_bc_ctrl1_read ERROR: Timed out waiting for GPIO to finish\n");
 	}
     }
     if (op_code_return_buf[0] != 0x01){
-	rp2040_log_w("test_max77958_bc_ctrl1_read ERROR: OPCODE should be 0x01");
+	rp2040_log_e("test_max77958_bc_ctrl1_read ERROR: OPCODE should be 0x01");
     }
     if (op_code_return_buf[1] != 0b10000001){
-        rp2040_log_w("test_max77958_bc_ctrl1_read ERROR: BC_CTRL1_CONFIG should be 0b10000001 instead it is 0b"
+        rp2040_log_e("test_max77958_bc_ctrl1_read ERROR: BC_CTRL1_CONFIG should be 0b10000001 instead it is 0b"
            BYTE_TO_BINARY_PATTERN "\n",
            BYTE_TO_BINARY(op_code_return_buf[1]));
     }else{
@@ -464,17 +464,17 @@ void test_max77958_bc_ctrl2_read(void)
     while (!opcodes_finished) {
         sleep_ms(100);
         if (++i > 10) {
-            rp2040_log_w("test_max77958_bc_ctrl2_read ERROR: Timed out waiting for response\n");
+            rp2040_log_e("test_max77958_bc_ctrl2_read ERROR: Timed out waiting for response\n");
         }
     }
 
     if (op_code_return_buf[0] != 0x03) {
-		rp2040_log_w("test_max77958_bc_ctrl2_read ERROR: OPCODE should be 0x03 (got 0x%02x)\n",
+		rp2040_log_e("test_max77958_bc_ctrl2_read ERROR: OPCODE should be 0x03 (got 0x%02x)\n",
 				   op_code_return_buf[0]);
 	}
 
     if (op_code_return_buf[1] != 0b00000001) {
-        rp2040_log_w("test_max77958_bc_ctrl2_read ERROR: OPCODE should be 0b00000001 got 0b"
+        rp2040_log_e("test_max77958_bc_ctrl2_read ERROR: OPCODE should be 0b00000001 got 0b"
 	   BYTE_TO_BINARY_PATTERN "\n",
 	   BYTE_TO_BINARY(op_code_return_buf[1]));
     }else{
@@ -504,17 +504,17 @@ void test_max77958_control1_read(void)
     while (!opcodes_finished) {
         sleep_ms(100);
         if (++i > 10) {
-            rp2040_log_w("test_max77958_control1_read ERROR: Timed out waiting for response\n");
+            rp2040_log_e("test_max77958_control1_read ERROR: Timed out waiting for response\n");
         }
     }
 
     if (op_code_return_buf[0] != 0x05) {
-        rp2040_log_w("test_max77958_control1_read ERROR: OPCODE should be 0x05 (got 0x%02x)\n",
+        rp2040_log_e("test_max77958_control1_read ERROR: OPCODE should be 0x05 (got 0x%02x)\n",
     			   op_code_return_buf[0]);
     }
 
     if (op_code_return_buf[1] != 0b00000000) {
-        rp2040_log_w("test_max77958_control1_read ERROR: OPCODE should be 0b00000000 (got 0b"
+        rp2040_log_e("test_max77958_control1_read ERROR: OPCODE should be 0b00000000 (got 0b"
 	   BYTE_TO_BINARY_PATTERN ")\n",
 	   BYTE_TO_BINARY(op_code_return_buf[1]));
     }else{
@@ -541,14 +541,14 @@ void test_max77958_cc_ctrl1_read(){
 	sleep_ms(100);
 	i++;
 	if (i > 10){
-	    rp2040_log_w("test_max77958_cc_ctrl1_read ERROR: Timed out waiting for GPIO to finish\n");
+	    rp2040_log_e("test_max77958_cc_ctrl1_read ERROR: Timed out waiting for GPIO to finish\n");
 	}
     }
     if (op_code_return_buf[0] != 0x0B){
-	rp2040_log_w("test_max77958_cc_ctrl1_read ERROR: OPCODE should be 0x0B");
+	rp2040_log_e("test_max77958_cc_ctrl1_read ERROR: OPCODE should be 0x0B");
     }
     if (op_code_return_buf[1] != 0b10000001){
-        rp2040_log_w("test_max77958_cc_ctrl1_read ERROR: CC_CTRL1_CONFIG should be 0b10000001 instead it is 0b"
+        rp2040_log_e("test_max77958_cc_ctrl1_read ERROR: CC_CTRL1_CONFIG should be 0b10000001 instead it is 0b"
            BYTE_TO_BINARY_PATTERN "\n",
            BYTE_TO_BINARY(op_code_return_buf[1]));
     }else{
@@ -578,17 +578,17 @@ void test_max77958_cc_ctrl4_read(void)
     while (!opcodes_finished) {
         sleep_ms(100);
         if (++i > 10) {
-            rp2040_log_w("test_max77958_cc_ctrl4_read ERROR: Timed out waiting for response\n");
+            rp2040_log_e("test_max77958_cc_ctrl4_read ERROR: Timed out waiting for response\n");
         }
     }
 
     if (op_code_return_buf[0] != 0x11) {
-        rp2040_log_w("test_max77958_cc_ctrl4_read ERROR: OPCODE should be 0x11 (got 0x%02x)\n",
+        rp2040_log_e("test_max77958_cc_ctrl4_read ERROR: OPCODE should be 0x11 (got 0x%02x)\n",
                    op_code_return_buf[0]);
     }
 
     if (op_code_return_buf[1] != 0b00000000) {
-		rp2040_log_w("test_max77958_cc_ctrl4_read ERROR: OPCODE should be 0b00000000 (got 0b"
+		rp2040_log_e("test_max77958_cc_ctrl4_read ERROR: OPCODE should be 0b00000000 (got 0b"
 				   BYTE_TO_BINARY_PATTERN ")\n",
 				   BYTE_TO_BINARY(op_code_return_buf[1]));
     }else{
@@ -617,31 +617,31 @@ void test_max77958_gpio_control_read(void)
     while (!opcodes_finished) {
         sleep_ms(100);
         if (++i > 10) {
-            rp2040_log_w("test_max77958_gpio_control_read ERROR: Timed out waiting for response\n");
+            rp2040_log_e("test_max77958_gpio_control_read ERROR: Timed out waiting for response\n");
         }
     }
 
     if (op_code_return_buf[0] != 0x23) {
-        rp2040_log_w("test_max77958_gpio_control_read ERROR: OPCODE should be 0x23 (got 0x%02x)\n",
+        rp2040_log_e("test_max77958_gpio_control_read ERROR: OPCODE should be 0x23 (got 0x%02x)\n",
                    op_code_return_buf[0]);
     }
 
     int error_count = 0;
 
     if (op_code_return_buf[1] != 0b00000000) {
-	rp2040_log_w("test_max77958_gpio_control_read ERROR: OPCODE should be 0b00000000 (got 0b"
+	rp2040_log_e("test_max77958_gpio_control_read ERROR: OPCODE should be 0b00000000 (got 0b"
 	   BYTE_TO_BINARY_PATTERN ")\n",
 	   BYTE_TO_BINARY(op_code_return_buf[1]));
 	error_count++;
     }
     if (op_code_return_buf[2] != 0b00000000) {
-	rp2040_log_w("test_max77958_gpio_control_read ERROR: OPCODE should be 0b00000000 (got 0b"
+	rp2040_log_e("test_max77958_gpio_control_read ERROR: OPCODE should be 0b00000000 (got 0b"
 	   BYTE_TO_BINARY_PATTERN ")\n",
 	   BYTE_TO_BINARY(op_code_return_buf[2]));
 	error_count++;
     }
     if (op_code_return_buf[3] != 0b00000000) {
-        rp2040_log_w("test_max77958_gpio_control_read ERROR: OPCODE should be 0b00000000 (got 0b"
+        rp2040_log_e("test_max77958_gpio_control_read ERROR: OPCODE should be 0b00000000 (got 0b"
     	   BYTE_TO_BINARY_PATTERN ")\n",
     	   BYTE_TO_BINARY(op_code_return_buf[3]));
 		error_count++;
@@ -677,20 +677,20 @@ void test_max77958_gpio0_gpio1_adc_read(void)
     while (!opcodes_finished) {
         sleep_ms(100);
         if (++i > 10) {
-            rp2040_log_w("test_max77958_gpio0_gpio1_adc_read ERROR: Timed out waiting for response\n");
+            rp2040_log_e("test_max77958_gpio0_gpio1_adc_read ERROR: Timed out waiting for response\n");
         }
     }
 
     if (op_code_return_buf[0] != 0x27) {
-        rp2040_log_w("test_max77958_gpio0_gpio1_adc_read ERROR: OPCODE should be 0x27 (got 0x%02x)\n",
+        rp2040_log_e("test_max77958_gpio0_gpio1_adc_read ERROR: OPCODE should be 0x27 (got 0x%02x)\n",
                    op_code_return_buf[0]);
     }
 
     if (op_code_return_buf[1] != 0b00000000 || op_code_return_buf[2] != 0b00000000) {
-	rp2040_log_w("test_max77958_gpio0_gpio1_adc_read ERROR: SBU1 should be 0b00000000 (got 0b"
+	rp2040_log_e("test_max77958_gpio0_gpio1_adc_read ERROR: SBU1 should be 0b00000000 (got 0b"
 	   BYTE_TO_BINARY_PATTERN ")\n",
 	   BYTE_TO_BINARY(op_code_return_buf[1]));
-	rp2040_log_w("test_max77958_gpio0_gpio1_adc_read ERROR: SBU2 should be 0b00000000 (got 0b"
+	rp2040_log_e("test_max77958_gpio0_gpio1_adc_read ERROR: SBU2 should be 0b00000000 (got 0b"
 	   BYTE_TO_BINARY_PATTERN ")\n",
 	   BYTE_TO_BINARY(op_code_return_buf[2]));
     }else{
@@ -729,11 +729,11 @@ void test_max77958_snk_pdo_request(void)
     while (!opcodes_finished) {
         sleep_ms(100);
         if (++i > 10) {
-            rp2040_log_w("test_max77958_snk_pdo_request ERROR: Timed out waiting for MTP\n");
+            rp2040_log_e("test_max77958_snk_pdo_request ERROR: Timed out waiting for MTP\n");
         }
     }
     if (op_code_return_buf[0] != 0x3E) {
-        rp2040_log_w("test_max77958_snk_pdo_request ERROR: OPCODE echo mismatch for MTP (got 0x%02x)\n",
+        rp2040_log_e("test_max77958_snk_pdo_request ERROR: OPCODE echo mismatch for MTP (got 0x%02x)\n",
                    op_code_return_buf[0]);
     }
 
@@ -755,11 +755,11 @@ void test_max77958_snk_pdo_request(void)
     while (!opcodes_finished) {
         sleep_ms(100);
         if (++i > 10) {
-            rp2040_log_w("test_max77958_snk_pdo_request ERROR: Timed out waiting for RAM\n");
+            rp2040_log_e("test_max77958_snk_pdo_request ERROR: Timed out waiting for RAM\n");
         }
     }
     if (op_code_return_buf[0] != 0x3E) {
-        rp2040_log_w("test_max77958_snk_pdo_request ERROR: OPCODE echo mismatch for RAM (got 0x%02x)\n",
+        rp2040_log_e("test_max77958_snk_pdo_request ERROR: OPCODE echo mismatch for RAM (got 0x%02x)\n",
                    op_code_return_buf[0]);
     }
 
@@ -795,17 +795,17 @@ void test_max77958_get_customer_config(){
 	sleep_ms(100);
 	i++;
 	if (i > 10){
-	    rp2040_log_w("test_max77958_get_customer_config ERROR: Timed out waiting for GPIO to finish\n");
+	    rp2040_log_e("test_max77958_get_customer_config ERROR: Timed out waiting for GPIO to finish\n");
 	}
     }
     if (op_code_return_buf[0] != 0x55){
-	rp2040_log_w("test_max77958_get_customer_config ERROR: OPCODE should be 0x55");
+	rp2040_log_e("test_max77958_get_customer_config ERROR: OPCODE should be 0x55");
     }
     if ((op_code_return_buf[2] | (op_code_return_buf[3] << 8)) != 0x0B6A){
-        rp2040_log_w("test_max77958_get_customer_config ERROR: CUSTOMER_CONFIG_ID should be 0x0B6A");
+        rp2040_log_e("test_max77958_get_customer_config ERROR: CUSTOMER_CONFIG_ID should be 0x0B6A");
     }
     if ((op_code_return_buf[4] | (op_code_return_buf[5] << 8)) != 0x6860){
-	rp2040_log_w("test_max77958_get_customer_config ERROR: CUSTOMER_CONFIG_REV should be 0x6860");
+	rp2040_log_e("test_max77958_get_customer_config ERROR: CUSTOMER_CONFIG_REV should be 0x6860");
     }
     rp2040_log_i("test_max77958_get_customer_config: 0x51=0x%02x\n", op_code_return_buf[0]);
     rp2040_log_i("test_max77958_get_customer_config: 0x52=0x%02x\n", op_code_return_buf[1]);
@@ -835,7 +835,7 @@ void test_max77958_interrupt(){
     rp2040_log_i("test_max77958_interrupt: prior to driving low GPIO%d. Current Value:%d\n", _gpio_interrupt, gpio_get(_gpio_interrupt));
     gpio_set_dir(_gpio_interrupt, GPIO_OUT);
     if (gpio_get(_gpio_interrupt) != 0){
-	rp2040_log_w("ERROR: test_max77958_interrupt: GPIO%d was not driven low. Current Value:%d\n", _gpio_interrupt, gpio_get(_gpio_interrupt));
+	rp2040_log_e("ERROR: test_max77958_interrupt: GPIO%d was not driven low. Current Value:%d\n", _gpio_interrupt, gpio_get(_gpio_interrupt));
     }
     rp2040_log_i("test_max77958_interrupt: after driving low GPIO%d. Current Value:%d\n", _gpio_interrupt, gpio_get(_gpio_interrupt));
     uint32_t i = 0;
@@ -844,7 +844,7 @@ void test_max77958_interrupt(){
 	tight_loop_contents();
 	i++;
 	if (i > 1000){
-	    rp2040_log_w("ERROR: test_max77958_interrupt timed out\n");
+	    rp2040_log_e("ERROR: test_max77958_interrupt timed out\n");
 	}
     }
     gpio_set_dir(_gpio_interrupt, GPIO_IN);
@@ -1157,7 +1157,7 @@ void max77958_shutdown(uint gpio_interrupt){
 	sleep_ms(100);
 	i++;
 	if (i > 10){
-	    rp2040_log_w("ERROR: Timed out waiting for GPIO to finish\n");
+	    rp2040_log_e("ERROR: Timed out waiting for GPIO to finish\n");
 	}
     }
 }

--- a/src/max77958.c
+++ b/src/max77958.c
@@ -78,7 +78,7 @@ void max77958_on_interrupt(uint gpio, uint32_t event_mask){
 }
 
 static int on_pd_msg_received(){
-    rp2040_log("Rec PD message\n");
+    rp2040_log_d("Rec PD message\n");
     call_queue_try_add(&pd_msg_response, 0);
     return 0;
 }
@@ -94,7 +94,7 @@ static int on_opcode_cmd_response(){
 }
 
 static void on_ccstat_change(void) {
-    rp2040_log("CCStat: ccstat changed\n");
+    rp2040_log_d("CCStat: ccstat changed\n");
 
     memset(send_buf, 0, sizeof send_buf);
     memset(return_buf, 0, sizeof return_buf);
@@ -118,19 +118,19 @@ static void on_ccstat_change(void) {
     bool DetAbrt   = cc_status1 & 0b00000100;  // bit [2]
     bool Wtr       = cc_status1 & 0b00000010;  // bit [1]
 
-    rp2040_log("  CCStat: CCPinStat=%s\n",
+    rp2040_log_d("  CCStat: CCPinStat=%s\n",
         (CCPinStat == 0b00000000 ? "00 (none)" :
         (CCPinStat == 0b01000000 ? "01 (CC1)" :
         (CCPinStat == 0b10000000 ? "10 (CC2)" : "11 (reserved)"))));
 
-    rp2040_log("  CCStat: CCIStat=%s\n",
+    rp2040_log_d("  CCStat: CCIStat=%s\n",
         (CCIStat == 0b00000000 ? "00 (none)" :
         (CCIStat == 0b00010000 ? "01 (500mA)" :
         (CCIStat == 0b00100000 ? "10 (1.5A)" : "11 (3.0A)"))));
 
-    rp2040_log("  CCStat: CCVcnStat=%s\n", CCVcnStat ? "1 (VCONN ON)" : "0 (VCONN OFF)");
+    rp2040_log_d("  CCStat: CCVcnStat=%s\n", CCVcnStat ? "1 (VCONN ON)" : "0 (VCONN OFF)");
 
-    rp2040_log("  CCStat=%s\n",
+    rp2040_log_d("  CCStat=%s\n",
         (CCStat == 0b000 ? "000 (none)" :
         (CCStat == 0b001 ? "001 (sink)" :
         (CCStat == 0b010 ? "010 (source)" :
@@ -142,37 +142,37 @@ static void on_ccstat_change(void) {
     // ---- Original CCStat switch preserved exactly ----
     switch (CCStat){
         case 0b000:
-            rp2040_log("CCStat: ccstat changed to no connection\n");
+            rp2040_log_d("CCStat: ccstat changed to no connection\n");
             vbus_turn_off();
             break;
         case 0b001:
-            rp2040_log("CCStat: ccstat changed to SINK\n");
+            rp2040_log_d("CCStat: ccstat changed to SINK\n");
             vbus_turn_off();
             break;
         case 0b010:
-            rp2040_log("CCStat: ccstat changed to SOURCE\n");
+            rp2040_log_d("CCStat: ccstat changed to SOURCE\n");
             //vbus_turn_on();
             break;
         default:
-            rp2040_log("CCStat: ccstat changed to %d\n", CCStat);
+            rp2040_log_d("CCStat: ccstat changed to %d\n", CCStat);
             break;
     }
 
     // ---- Fault / condition flags ----
     if (Wtr)
-        rp2040_log("ERROR: CCStat: Moisture detected on CC (Wtr=1)\n");
+        rp2040_log_e("ERROR: CCStat: Moisture detected on CC (Wtr=1)\n");
     if (DetAbrt)
-        rp2040_log("ERROR: CCStat: Charger detection aborted (DetAbrt=1)\n");
+        rp2040_log_e("ERROR: CCStat: Charger detection aborted (DetAbrt=1)\n");
     if (VSafeOV)
-        rp2040_log("ERROR: CCStat: VBUS overvoltage detected (VSafeOV=1)\n");
+        rp2040_log_e("ERROR: CCStat: VBUS overvoltage detected (VSafeOV=1)\n");
     if (VCONN_SC)
-        rp2040_log("ERROR: CCStat: VCONN short-circuit detected (VCONN_SC=1)\n");
+        rp2040_log_e("ERROR: CCStat: VCONN short-circuit detected (VCONN_SC=1)\n");
     if (VCONN_OCP)
-        rp2040_log("ERROR: CCStat: VCONN overcurrent detected (VCONN_OCP=1)\n");
+        rp2040_log_e("ERROR: CCStat: VCONN overcurrent detected (VCONN_OCP=1)\n");
 }
 
 static void on_chgtype_change(){
-    rp2040_log("chgtype changed\n");
+    rp2040_log_d("chgtype changed\n");
     memset(send_buf, 0, sizeof send_buf);
     memset(return_buf, 0, sizeof return_buf);
     send_buf[0] = 0xA; // BC_STATUS
@@ -181,16 +181,16 @@ static void on_chgtype_change(){
     uint8_t ChgType = return_buf[0] & 0b11;
     switch (ChgType){
 	case 0b000:
-	    rp2040_log("ChgTyp changed to nothing attached\n");
+	    rp2040_log_d("ChgTyp changed to nothing attached\n");
 	    break;
 	case 0b001:
-	    rp2040_log("ChgTyp changed to SDP, USB cable attached\n");
+	    rp2040_log_d("ChgTyp changed to SDP, USB cable attached\n");
 	    break;
 	case 0b010:
-	    rp2040_log("ChgTyp changed to CDP, Charging Downstream Port\n");
+	    rp2040_log_d("ChgTyp changed to CDP, Charging Downstream Port\n");
 	    break;
 	default: 
-	    rp2040_log("ChgTyp changed to DCP, Dedicated charger\n");
+	    rp2040_log_d("ChgTyp changed to DCP, Dedicated charger\n");
 	    break;
 	}
 }
@@ -199,10 +199,10 @@ static void opcode_queue_add(int32_t (opcode_func)(), int32_t opcode_data){
     opcodes_finished = false;
     queue_entry_t opcode_entry = {opcode_func, opcode_data};
     if(!queue_try_add(&opcode_queue, &opcode_entry)){
-	rp2040_log("ERROR: opcode_queue is full");
+	rp2040_log_e("ERROR: opcode_queue is full");
 	assert(false);
     }
-    rp2040_log("Added to opcode_queue. %d entries remaining\n", queue_get_level(&opcode_queue));
+    rp2040_log_d("Added to opcode_queue. %d entries remaining\n", queue_get_level(&opcode_queue));
 } 
 
 static int32_t parse_interrupt_vals(){
@@ -226,7 +226,7 @@ static int32_t parse_interrupt_vals(){
 	return_val |= 1 << 0;
     }
     if (*PD_INT & PSRDYI_mask){
-	rp2040_log("Power source ready\n");
+	rp2040_log_d("Power source ready\n");
 	//on_power_source_ready();
 	return_val |= 1 << 1;
     }
@@ -263,15 +263,15 @@ static int32_t parse_interrupt_vals(){
 }
 
 static void on_ccvcnstat_change(){
-    rp2040_log("CCStat changed\n");
+    rp2040_log_d("CCStat changed\n");
 }
 
 static void on_ccistat_change(){
-    rp2040_log("CCIStat changed\n");
+    rp2040_log_d("CCIStat changed\n");
 }
 
 static void on_ccpinstat_change(){
-    rp2040_log("CCPinStat changed\n");
+    rp2040_log_d("CCPinStat changed\n");
 }
 
 static void get_interrupt_vals(){
@@ -316,7 +316,7 @@ void read_reg(uint8_t reg){
     send_buf[0] = reg; 
     i2c_write_error_handling(i2c0, MAX77958_SLAVE_P1, send_buf, 1, true);
     i2c_read_error_handling(i2c0, MAX77958_SLAVE_P1, return_buf, 1, false);
-    rp2040_log("read_reg: 0x%02x: 0x%02x\n", reg, return_buf[0]);
+    rp2040_log_d("read_reg: 0x%02x: 0x%02x\n", reg, return_buf[0]);
 }
 
 static int opcode_write(uint8_t *buf){
@@ -324,7 +324,7 @@ static int opcode_write(uint8_t *buf){
     // so you may send wrong data if you don't directly specify them for ALL registers. Note the defaults are NOT always 0x00,
     // so you should send all values everytime. What a pain...
     if (buf[0] != 0x21){
-	rp2040_log("ERROR: buffer should always start with the 0x21 register");
+	rp2040_log_w("ERROR: buffer should always start with the 0x21 register");
     }
 
     i2c_write_error_handling(i2c0, MAX77958_SLAVE_P1, buf, sizeof(send_buf), false);
@@ -344,7 +344,7 @@ static void opcode_read(){
     send_buf[0] = OPCODE_READ_COMMAND;
     i2c_write_error_handling(i2c0, MAX77958_SLAVE_P1, send_buf, 1, true);
     i2c_read_error_handling(i2c0, MAX77958_SLAVE_P1, op_code_return_buf, 33, false);
-    rp2040_log("opcode_read: 0x%02x 0x%02x 0x%02x 0x%02x\n", op_code_return_buf[0], op_code_return_buf[1], op_code_return_buf[2], op_code_return_buf[3]);
+    rp2040_log_d("opcode_read: 0x%02x 0x%02x 0x%02x 0x%02x\n", op_code_return_buf[0], op_code_return_buf[1], op_code_return_buf[2], op_code_return_buf[3]);
     // Set breakpoint before clearing the registers via the following command. 
     // I'm commenting this out since I won't use the output in the code, but you can copy/paste this into gdb if you want to
     // inspect the results before clearing them
@@ -378,23 +378,23 @@ void test_max77958_status_block_read_all(void)
         {"PD_STATUS1",   0x0F, 0b00000000}
     };
 
-    rp2040_log("test_max77958_status_block_read_all started...\n");
+    rp2040_log_i("test_max77958_status_block_read_all started...\n");
 
     for (uint8_t i = 0; i < sizeof(regs) / sizeof(regs[0]); i++) {
         uint8_t val = max77958_read_register(regs[i].reg);
 
         if (val != regs[i].expected)
-            rp2040_log("test_max77958_status_block_read_all ERROR: %s expected 0b" BYTE_TO_BINARY_PATTERN ", got 0b" BYTE_TO_BINARY_PATTERN "\n",
+            rp2040_log_w("test_max77958_status_block_read_all ERROR: %s expected 0b" BYTE_TO_BINARY_PATTERN ", got 0b" BYTE_TO_BINARY_PATTERN "\n",
                        regs[i].name, BYTE_TO_BINARY(regs[i].expected), BYTE_TO_BINARY(val));
         else
-            rp2040_log("test_max77958_status_block_read_all PASSED: %s matches reset value 0b" BYTE_TO_BINARY_PATTERN "\n",
+            rp2040_log_i("test_max77958_status_block_read_all PASSED: %s matches reset value 0b" BYTE_TO_BINARY_PATTERN "\n",
                        regs[i].name, BYTE_TO_BINARY(val));
     }
 }
 
 
 void test_max77958_get_id(){
-    rp2040_log("test_max77958_get_id started...\n");
+    rp2040_log_i("test_max77958_get_id started...\n");
     // Testing for just DEVICE_ID
     // Write the register 0x00 to set the pointer there before reading its value
     memset(send_buf, 0, sizeof send_buf);
@@ -402,13 +402,13 @@ void test_max77958_get_id(){
     i2c_write_error_handling(i2c0, MAX77958_SLAVE_P1, send_buf, 1, true);
     i2c_read_error_handling(i2c0, MAX77958_SLAVE_P1, return_buf, 2, false);
     if (return_buf[0] != 0x58){
-	rp2040_log("test_max77958_get_id ERROR: DEVICE_ID should be 0x58");
+	rp2040_log_w("test_max77958_get_id ERROR: DEVICE_ID should be 0x58");
     }
     if (return_buf[1] != 0x02){
-	rp2040_log("test_max77958_get_id ERROR: DEVICE_REV should be 0x02");
+	rp2040_log_w("test_max77958_get_id ERROR: DEVICE_REV should be 0x02");
     }
-    rp2040_log("test_max77958_get_id PASSED: DEVICE_ID = %x\n", return_buf[0]);
-    rp2040_log("test_max77958_get_id PASSED: DEVICE_REV = %x\n", return_buf[1]);
+    rp2040_log_i("test_max77958_get_id PASSED: DEVICE_ID = %x\n", return_buf[0]);
+    rp2040_log_i("test_max77958_get_id PASSED: DEVICE_REV = %x\n", return_buf[1]);
 }
 
 static int32_t bc_ctrl1_read(){
@@ -420,7 +420,7 @@ static int32_t bc_ctrl1_read(){
 }
 
 void test_max77958_bc_ctrl1_read(){
-    rp2040_log("test_max77958_bc_ctrl1_read started...\n");
+    rp2040_log_i("test_max77958_bc_ctrl1_read started...\n");
     opcode_queue_add(bc_ctrl1_read, 0);
     opcode_queue_pop();
     int i = 0;
@@ -428,18 +428,18 @@ void test_max77958_bc_ctrl1_read(){
 	sleep_ms(100);
 	i++;
 	if (i > 10){
-	    rp2040_log("test_max77958_bc_ctrl1_read ERROR: Timed out waiting for GPIO to finish\n");
+	    rp2040_log_w("test_max77958_bc_ctrl1_read ERROR: Timed out waiting for GPIO to finish\n");
 	}
     }
     if (op_code_return_buf[0] != 0x01){
-	rp2040_log("test_max77958_bc_ctrl1_read ERROR: OPCODE should be 0x01");
+	rp2040_log_w("test_max77958_bc_ctrl1_read ERROR: OPCODE should be 0x01");
     }
     if (op_code_return_buf[1] != 0b10000001){
-        rp2040_log("test_max77958_bc_ctrl1_read ERROR: BC_CTRL1_CONFIG should be 0b10000001 instead it is 0b"
+        rp2040_log_w("test_max77958_bc_ctrl1_read ERROR: BC_CTRL1_CONFIG should be 0b10000001 instead it is 0b"
            BYTE_TO_BINARY_PATTERN "\n",
            BYTE_TO_BINARY(op_code_return_buf[1]));
     }else{
-	rp2040_log("test_max77958_bc_ctrl1_read PASSED: BC_CTRL1_CONFIG = 0b"
+	rp2040_log_i("test_max77958_bc_ctrl1_read PASSED: BC_CTRL1_CONFIG = 0b"
 	   BYTE_TO_BINARY_PATTERN "\n",
 	   BYTE_TO_BINARY(op_code_return_buf[1]));
     }
@@ -456,7 +456,7 @@ static int32_t bc_ctrl2_read()
 
 void test_max77958_bc_ctrl2_read(void)
 {
-    rp2040_log("test_max77958_bc_ctrl2_read started...\n");
+    rp2040_log_i("test_max77958_bc_ctrl2_read started...\n");
     opcode_queue_add(bc_ctrl2_read, 0);
     opcode_queue_pop();
 
@@ -464,21 +464,21 @@ void test_max77958_bc_ctrl2_read(void)
     while (!opcodes_finished) {
         sleep_ms(100);
         if (++i > 10) {
-            rp2040_log("test_max77958_bc_ctrl2_read ERROR: Timed out waiting for response\n");
+            rp2040_log_w("test_max77958_bc_ctrl2_read ERROR: Timed out waiting for response\n");
         }
     }
 
     if (op_code_return_buf[0] != 0x03) {
-		rp2040_log("test_max77958_bc_ctrl2_read ERROR: OPCODE should be 0x03 (got 0x%02x)\n",
+		rp2040_log_w("test_max77958_bc_ctrl2_read ERROR: OPCODE should be 0x03 (got 0x%02x)\n",
 				   op_code_return_buf[0]);
 	}
 
     if (op_code_return_buf[1] != 0b00000001) {
-        rp2040_log("test_max77958_bc_ctrl2_read ERROR: OPCODE should be 0b00000001 got 0b"
+        rp2040_log_w("test_max77958_bc_ctrl2_read ERROR: OPCODE should be 0b00000001 got 0b"
 	   BYTE_TO_BINARY_PATTERN "\n",
 	   BYTE_TO_BINARY(op_code_return_buf[1]));
     }else{
-	rp2040_log("test_max77958_bc_ctrl2_read PASSED: BC_CTRL2_CONFIG = 0b"
+	rp2040_log_i("test_max77958_bc_ctrl2_read PASSED: BC_CTRL2_CONFIG = 0b"
            BYTE_TO_BINARY_PATTERN "\n",
            BYTE_TO_BINARY(op_code_return_buf[1]));
     }
@@ -496,7 +496,7 @@ static int32_t control1_read()
 
 void test_max77958_control1_read(void)
 {
-    rp2040_log("test_max77958_control1_read started...\n");
+    rp2040_log_i("test_max77958_control1_read started...\n");
     opcode_queue_add(control1_read, 0);
     opcode_queue_pop();
 
@@ -504,21 +504,21 @@ void test_max77958_control1_read(void)
     while (!opcodes_finished) {
         sleep_ms(100);
         if (++i > 10) {
-            rp2040_log("test_max77958_control1_read ERROR: Timed out waiting for response\n");
+            rp2040_log_w("test_max77958_control1_read ERROR: Timed out waiting for response\n");
         }
     }
 
     if (op_code_return_buf[0] != 0x05) {
-    	rp2040_log("test_max77958_control1_read ERROR: OPCODE should be 0x05 (got 0x%02x)\n",
+        rp2040_log_w("test_max77958_control1_read ERROR: OPCODE should be 0x05 (got 0x%02x)\n",
     			   op_code_return_buf[0]);
     }
 
     if (op_code_return_buf[1] != 0b00000000) {
-        rp2040_log("test_max77958_control1_read ERROR: OPCODE should be 0b00000000 (got 0b"
+        rp2040_log_w("test_max77958_control1_read ERROR: OPCODE should be 0b00000000 (got 0b"
 	   BYTE_TO_BINARY_PATTERN ")\n",
 	   BYTE_TO_BINARY(op_code_return_buf[1]));
     }else{
-	rp2040_log("test_max77958_control1_read PASSED: CONTROL1_CONFIG = 0b"
+	rp2040_log_i("test_max77958_control1_read PASSED: CONTROL1_CONFIG = 0b"
            BYTE_TO_BINARY_PATTERN "\n",
            BYTE_TO_BINARY(op_code_return_buf[1]));
     }
@@ -533,7 +533,7 @@ static int32_t cc_ctrl1_read(){
 }
 
 void test_max77958_cc_ctrl1_read(){
-    rp2040_log("test_max77958_cc_ctrl1_read started...\n");
+    rp2040_log_i("test_max77958_cc_ctrl1_read started...\n");
     opcode_queue_add(cc_ctrl1_read, 0);
     opcode_queue_pop();
     int i = 0;
@@ -541,18 +541,18 @@ void test_max77958_cc_ctrl1_read(){
 	sleep_ms(100);
 	i++;
 	if (i > 10){
-	    rp2040_log("test_max77958_cc_ctrl1_read ERROR: Timed out waiting for GPIO to finish\n");
+	    rp2040_log_w("test_max77958_cc_ctrl1_read ERROR: Timed out waiting for GPIO to finish\n");
 	}
     }
     if (op_code_return_buf[0] != 0x0B){
-	rp2040_log("test_max77958_cc_ctrl1_read ERROR: OPCODE should be 0x0B");
+	rp2040_log_w("test_max77958_cc_ctrl1_read ERROR: OPCODE should be 0x0B");
     }
     if (op_code_return_buf[1] != 0b10000001){
-        rp2040_log("test_max77958_cc_ctrl1_read ERROR: CC_CTRL1_CONFIG should be 0b10000001 instead it is 0b"
+        rp2040_log_w("test_max77958_cc_ctrl1_read ERROR: CC_CTRL1_CONFIG should be 0b10000001 instead it is 0b"
            BYTE_TO_BINARY_PATTERN "\n",
            BYTE_TO_BINARY(op_code_return_buf[1]));
     }else{
-	rp2040_log("test_max77958_cc_ctrl1_read PASSED: CC_CTRL1_CONFIG = 0b"
+	rp2040_log_i("test_max77958_cc_ctrl1_read PASSED: CC_CTRL1_CONFIG = 0b"
 	   BYTE_TO_BINARY_PATTERN "\n",
 	   BYTE_TO_BINARY(op_code_return_buf[1]));
     }
@@ -570,7 +570,7 @@ static int32_t cc_ctrl4_read(void)
 
 void test_max77958_cc_ctrl4_read(void)
 {
-    rp2040_log("test_max77958_cc_ctrl4_read started...\n");
+    rp2040_log_i("test_max77958_cc_ctrl4_read started...\n");
     opcode_queue_add(cc_ctrl4_read, 0);
     opcode_queue_pop();
 
@@ -578,21 +578,21 @@ void test_max77958_cc_ctrl4_read(void)
     while (!opcodes_finished) {
         sleep_ms(100);
         if (++i > 10) {
-            rp2040_log("test_max77958_cc_ctrl4_read ERROR: Timed out waiting for response\n");
+            rp2040_log_w("test_max77958_cc_ctrl4_read ERROR: Timed out waiting for response\n");
         }
     }
 
     if (op_code_return_buf[0] != 0x11) {
-        rp2040_log("test_max77958_cc_ctrl4_read ERROR: OPCODE should be 0x11 (got 0x%02x)\n",
+        rp2040_log_w("test_max77958_cc_ctrl4_read ERROR: OPCODE should be 0x11 (got 0x%02x)\n",
                    op_code_return_buf[0]);
     }
 
     if (op_code_return_buf[1] != 0b00000000) {
-		rp2040_log("test_max77958_cc_ctrl4_read ERROR: OPCODE should be 0b00000000 (got 0b"
+		rp2040_log_w("test_max77958_cc_ctrl4_read ERROR: OPCODE should be 0b00000000 (got 0b"
 				   BYTE_TO_BINARY_PATTERN ")\n",
 				   BYTE_TO_BINARY(op_code_return_buf[1]));
     }else{
-	rp2040_log("test_max77958_cc_ctrl4_read PASSED: CC_CTRL4 = 0b"
+	rp2040_log_i("test_max77958_cc_ctrl4_read PASSED: CC_CTRL4 = 0b"
            BYTE_TO_BINARY_PATTERN "\n",
            BYTE_TO_BINARY(op_code_return_buf[1]));
     }
@@ -609,7 +609,7 @@ static int32_t gpio_control_read(void)
 
 void test_max77958_gpio_control_read(void)
 {
-    rp2040_log("test_max77958_gpio_control_read started...\n");
+    rp2040_log_i("test_max77958_gpio_control_read started...\n");
     opcode_queue_add(gpio_control_read, 0);
     opcode_queue_pop();
 
@@ -617,37 +617,37 @@ void test_max77958_gpio_control_read(void)
     while (!opcodes_finished) {
         sleep_ms(100);
         if (++i > 10) {
-            rp2040_log("test_max77958_gpio_control_read ERROR: Timed out waiting for response\n");
+            rp2040_log_w("test_max77958_gpio_control_read ERROR: Timed out waiting for response\n");
         }
     }
 
     if (op_code_return_buf[0] != 0x23) {
-        rp2040_log("test_max77958_gpio_control_read ERROR: OPCODE should be 0x23 (got 0x%02x)\n",
+        rp2040_log_w("test_max77958_gpio_control_read ERROR: OPCODE should be 0x23 (got 0x%02x)\n",
                    op_code_return_buf[0]);
     }
 
     int error_count = 0;
 
     if (op_code_return_buf[1] != 0b00000000) {
-	rp2040_log("test_max77958_gpio_control_read ERROR: OPCODE should be 0b00000000 (got 0b"
+	rp2040_log_w("test_max77958_gpio_control_read ERROR: OPCODE should be 0b00000000 (got 0b"
 	   BYTE_TO_BINARY_PATTERN ")\n",
 	   BYTE_TO_BINARY(op_code_return_buf[1]));
 	error_count++;
     }
     if (op_code_return_buf[2] != 0b00000000) {
-	rp2040_log("test_max77958_gpio_control_read ERROR: OPCODE should be 0b00000000 (got 0b"
+	rp2040_log_w("test_max77958_gpio_control_read ERROR: OPCODE should be 0b00000000 (got 0b"
 	   BYTE_TO_BINARY_PATTERN ")\n",
 	   BYTE_TO_BINARY(op_code_return_buf[2]));
 	error_count++;
     }
     if (op_code_return_buf[3] != 0b00000000) {
-    	rp2040_log("test_max77958_gpio_control_read ERROR: OPCODE should be 0b00000000 (got 0b"
+        rp2040_log_w("test_max77958_gpio_control_read ERROR: OPCODE should be 0b00000000 (got 0b"
     	   BYTE_TO_BINARY_PATTERN ")\n",
     	   BYTE_TO_BINARY(op_code_return_buf[3]));
 		error_count++;
     }
     if (error_count > 0) {
-        rp2040_log("test_max77958_gpio_control_read PASSED: "
+        rp2040_log_i("test_max77958_gpio_control_read PASSED: "
            "0x52(GPIO0-3)=0b" BYTE_TO_BINARY_PATTERN " "
            "0x53(GPIO4-7)=0b" BYTE_TO_BINARY_PATTERN " "
            "0x54(GPIO8)=0b"   BYTE_TO_BINARY_PATTERN "\n",
@@ -669,7 +669,7 @@ static int32_t gpio0_gpio1_adc_read(void)
 
 void test_max77958_gpio0_gpio1_adc_read(void)
 {
-    rp2040_log("test_max77958_gpio0_gpio1_adc_read started...\n");
+    rp2040_log_i("test_max77958_gpio0_gpio1_adc_read started...\n");
     opcode_queue_add(gpio0_gpio1_adc_read, 0);
     opcode_queue_pop();
 
@@ -677,24 +677,24 @@ void test_max77958_gpio0_gpio1_adc_read(void)
     while (!opcodes_finished) {
         sleep_ms(100);
         if (++i > 10) {
-            rp2040_log("test_max77958_gpio0_gpio1_adc_read ERROR: Timed out waiting for response\n");
+            rp2040_log_w("test_max77958_gpio0_gpio1_adc_read ERROR: Timed out waiting for response\n");
         }
     }
 
     if (op_code_return_buf[0] != 0x27) {
-        rp2040_log("test_max77958_gpio0_gpio1_adc_read ERROR: OPCODE should be 0x27 (got 0x%02x)\n",
+        rp2040_log_w("test_max77958_gpio0_gpio1_adc_read ERROR: OPCODE should be 0x27 (got 0x%02x)\n",
                    op_code_return_buf[0]);
     }
 
     if (op_code_return_buf[1] != 0b00000000 || op_code_return_buf[2] != 0b00000000) {
-	rp2040_log("test_max77958_gpio0_gpio1_adc_read ERROR: SBU1 should be 0b00000000 (got 0b"
+	rp2040_log_w("test_max77958_gpio0_gpio1_adc_read ERROR: SBU1 should be 0b00000000 (got 0b"
 	   BYTE_TO_BINARY_PATTERN ")\n",
 	   BYTE_TO_BINARY(op_code_return_buf[1]));
-	rp2040_log("test_max77958_gpio0_gpio1_adc_read ERROR: SBU2 should be 0b00000000 (got 0b"
+	rp2040_log_w("test_max77958_gpio0_gpio1_adc_read ERROR: SBU2 should be 0b00000000 (got 0b"
 	   BYTE_TO_BINARY_PATTERN ")\n",
 	   BYTE_TO_BINARY(op_code_return_buf[2]));
     }else{
-	rp2040_log("test_max77958_gpio0_gpio1_adc_read PASSED: "
+	rp2040_log_i("test_max77958_gpio0_gpio1_adc_read PASSED: "
            "SBU1=0b" BYTE_TO_BINARY_PATTERN " "
            "SBU2=0b" BYTE_TO_BINARY_PATTERN "\n",
            BYTE_TO_BINARY(op_code_return_buf[1]),
@@ -719,7 +719,7 @@ static int32_t snk_pdo_request(void) {
 
 void test_max77958_snk_pdo_request(void)
 {
-    rp2040_log("test_max77958_snk_pdo_request started...\n");
+    rp2040_log_i("test_max77958_snk_pdo_request started...\n");
 
     // ---- Read MTP copy ----
     use_mtp_access = false;  // for RAM access
@@ -729,22 +729,22 @@ void test_max77958_snk_pdo_request(void)
     while (!opcodes_finished) {
         sleep_ms(100);
         if (++i > 10) {
-            rp2040_log("test_max77958_snk_pdo_request ERROR: Timed out waiting for MTP\n");
+            rp2040_log_w("test_max77958_snk_pdo_request ERROR: Timed out waiting for MTP\n");
         }
     }
     if (op_code_return_buf[0] != 0x3E) {
-        rp2040_log("test_max77958_snk_pdo_request ERROR: OPCODE echo mismatch for MTP (got 0x%02x)\n",
+        rp2040_log_w("test_max77958_snk_pdo_request ERROR: OPCODE echo mismatch for MTP (got 0x%02x)\n",
                    op_code_return_buf[0]);
     }
 
     uint8_t mtp_pdo_count = op_code_return_buf[1];
-    rp2040_log("test_max77958_snk_pdo_request MTP PDO count = %d\n", mtp_pdo_count);
+    rp2040_log_i("test_max77958_snk_pdo_request MTP PDO count = %d\n", mtp_pdo_count);
     for (int j = 0; j < mtp_pdo_count; j++) {
         uint32_t pdo = op_code_return_buf[2 + j * 4]
                      | (op_code_return_buf[3 + j * 4] << 8)
                      | (op_code_return_buf[4 + j * 4] << 16)
                      | (op_code_return_buf[5 + j * 4] << 24);
-        rp2040_log("test_max77958_snk_pdo_request MTP PDO[%d] = 0x%08" PRIx32 "\n", j, pdo);
+        rp2040_log_i("test_max77958_snk_pdo_request MTP PDO[%d] = 0x%08" PRIx32 "\n", j, pdo);
     }
 
     // ---- Read RAM copy ----
@@ -755,25 +755,25 @@ void test_max77958_snk_pdo_request(void)
     while (!opcodes_finished) {
         sleep_ms(100);
         if (++i > 10) {
-            rp2040_log("test_max77958_snk_pdo_request ERROR: Timed out waiting for RAM\n");
+            rp2040_log_w("test_max77958_snk_pdo_request ERROR: Timed out waiting for RAM\n");
         }
     }
     if (op_code_return_buf[0] != 0x3E) {
-        rp2040_log("test_max77958_snk_pdo_request ERROR: OPCODE echo mismatch for RAM (got 0x%02x)\n",
+        rp2040_log_w("test_max77958_snk_pdo_request ERROR: OPCODE echo mismatch for RAM (got 0x%02x)\n",
                    op_code_return_buf[0]);
     }
 
     uint8_t ram_pdo_count = op_code_return_buf[1];
-    rp2040_log("test_max77958_snk_pdo_request RAM PDO count = %d\n", ram_pdo_count);
+    rp2040_log_i("test_max77958_snk_pdo_request RAM PDO count = %d\n", ram_pdo_count);
     for (int j = 0; j < ram_pdo_count; j++) {
         uint32_t pdo = op_code_return_buf[2 + j * 4]
                      | (op_code_return_buf[3 + j * 4] << 8)
                      | (op_code_return_buf[4 + j * 4] << 16)
                      | (op_code_return_buf[5 + j * 4] << 24);
-        rp2040_log("test_max77958_snk_pdo_request RAM PDO[%d] = 0x%08" PRIx32 "\n", j, pdo);
+        rp2040_log_i("test_max77958_snk_pdo_request RAM PDO[%d] = 0x%08" PRIx32 "\n", j, pdo);
     }
 
-    rp2040_log("test_max77958_snk_pdo_request PASSED: MTP=%d PDOs, RAM=%d PDOs\n",
+    rp2040_log_i("test_max77958_snk_pdo_request PASSED: MTP=%d PDOs, RAM=%d PDOs\n",
                mtp_pdo_count, ram_pdo_count);
 }
 
@@ -787,7 +787,7 @@ static int32_t customer_config_read(){
 }
 
 void test_max77958_get_customer_config(){
-    rp2040_log("test_max77958_get_customer_config started...\n");
+    rp2040_log_i("test_max77958_get_customer_config started...\n");
     opcode_queue_add(customer_config_read, 0);
     opcode_queue_pop();
     int i = 0;
@@ -795,56 +795,56 @@ void test_max77958_get_customer_config(){
 	sleep_ms(100);
 	i++;
 	if (i > 10){
-	    rp2040_log("test_max77958_get_customer_config ERROR: Timed out waiting for GPIO to finish\n");
+	    rp2040_log_w("test_max77958_get_customer_config ERROR: Timed out waiting for GPIO to finish\n");
 	}
     }
     if (op_code_return_buf[0] != 0x55){
-	rp2040_log("test_max77958_get_customer_config ERROR: OPCODE should be 0x55");
+	rp2040_log_w("test_max77958_get_customer_config ERROR: OPCODE should be 0x55");
     }
     if ((op_code_return_buf[2] | (op_code_return_buf[3] << 8)) != 0x0B6A){
-        rp2040_log("test_max77958_get_customer_config ERROR: CUSTOMER_CONFIG_ID should be 0x0B6A");
+        rp2040_log_w("test_max77958_get_customer_config ERROR: CUSTOMER_CONFIG_ID should be 0x0B6A");
     }
     if ((op_code_return_buf[4] | (op_code_return_buf[5] << 8)) != 0x6860){
-	rp2040_log("test_max77958_get_customer_config ERROR: CUSTOMER_CONFIG_REV should be 0x6860");
+	rp2040_log_w("test_max77958_get_customer_config ERROR: CUSTOMER_CONFIG_REV should be 0x6860");
     }
-    rp2040_log("test_max77958_get_customer_config: 0x51=0x%02x\n", op_code_return_buf[0]);
-    rp2040_log("test_max77958_get_customer_config: 0x52=0x%02x\n", op_code_return_buf[1]);
-    rp2040_log("test_max77958_get_customer_config: 0x52=0b"
+    rp2040_log_i("test_max77958_get_customer_config: 0x51=0x%02x\n", op_code_return_buf[0]);
+    rp2040_log_i("test_max77958_get_customer_config: 0x52=0x%02x\n", op_code_return_buf[1]);
+    rp2040_log_i("test_max77958_get_customer_config: 0x52=0b"
 		   BYTE_TO_BINARY_PATTERN "\n",
 		   BYTE_TO_BINARY(op_code_return_buf[1]));
 
-    rp2040_log("test_max77958_get_customer_config: 0x53=0x%02x\n", op_code_return_buf[2]);
-    rp2040_log("test_max77958_get_customer_config: 0x54=0x%02x\n", op_code_return_buf[3]);
-    rp2040_log("test_max77958_get_customer_config: 0x55=0x%02x\n", op_code_return_buf[4]);
-    rp2040_log("test_max77958_get_customer_config: 0x56=0x%02x\n", op_code_return_buf[5]);
-    rp2040_log("test_max77958_get_customer_config: 0x57=0x%02x\n", op_code_return_buf[6]);
-    rp2040_log("test_max77958_get_customer_config: 0x58=0x%02x\n", op_code_return_buf[7]);
-    rp2040_log("test_max77958_get_customer_config: 0x59=0x%02x\n", op_code_return_buf[8]);
-    rp2040_log("test_max77958_get_customer_config: 0x5A=0x%02x\n", op_code_return_buf[9]);
-    rp2040_log("test_max77958_get_customer_config: 0x5B=0x%02x\n", op_code_return_buf[10]);
+    rp2040_log_i("test_max77958_get_customer_config: 0x53=0x%02x\n", op_code_return_buf[2]);
+    rp2040_log_i("test_max77958_get_customer_config: 0x54=0x%02x\n", op_code_return_buf[3]);
+    rp2040_log_i("test_max77958_get_customer_config: 0x55=0x%02x\n", op_code_return_buf[4]);
+    rp2040_log_i("test_max77958_get_customer_config: 0x56=0x%02x\n", op_code_return_buf[5]);
+    rp2040_log_i("test_max77958_get_customer_config: 0x57=0x%02x\n", op_code_return_buf[6]);
+    rp2040_log_i("test_max77958_get_customer_config: 0x58=0x%02x\n", op_code_return_buf[7]);
+    rp2040_log_i("test_max77958_get_customer_config: 0x59=0x%02x\n", op_code_return_buf[8]);
+    rp2040_log_i("test_max77958_get_customer_config: 0x5A=0x%02x\n", op_code_return_buf[9]);
+    rp2040_log_i("test_max77958_get_customer_config: 0x5B=0x%02x\n", op_code_return_buf[10]);
 
-    rp2040_log("test_max77958_get_customer_config PASSED: CUSTOMER_CONFIG_ID = 0x%04x\n", (op_code_return_buf[2] | (op_code_return_buf[3] << 8)));
-    rp2040_log("test_max77958_get_customer_config PASSED: CUSTOMER_CONFIG_REV = 0x%04x\n", (op_code_return_buf[4] | (op_code_return_buf[5] << 8)));
+    rp2040_log_i("test_max77958_get_customer_config PASSED: CUSTOMER_CONFIG_ID = 0x%04x\n", (op_code_return_buf[2] | (op_code_return_buf[3] << 8)));
+    rp2040_log_i("test_max77958_get_customer_config PASSED: CUSTOMER_CONFIG_REV = 0x%04x\n", (op_code_return_buf[4] | (op_code_return_buf[5] << 8)));
 }
 
 void test_max77958_interrupt(){
-    rp2040_log("test_max77958_interrupt started...\n");
+    rp2040_log_i("test_max77958_interrupt started...\n");
     set_interrupt_masks_all_masked();
 
     test_max77958_started = true;
-    rp2040_log("test_max77958_interrupt: prior to driving low GPIO%d. Current Value:%d\n", _gpio_interrupt, gpio_get(_gpio_interrupt));
+    rp2040_log_i("test_max77958_interrupt: prior to driving low GPIO%d. Current Value:%d\n", _gpio_interrupt, gpio_get(_gpio_interrupt));
     gpio_set_dir(_gpio_interrupt, GPIO_OUT);
     if (gpio_get(_gpio_interrupt) != 0){
-	rp2040_log("ERROR: test_max77958_interrupt: GPIO%d was not driven low. Current Value:%d\n", _gpio_interrupt, gpio_get(_gpio_interrupt));
+	rp2040_log_w("ERROR: test_max77958_interrupt: GPIO%d was not driven low. Current Value:%d\n", _gpio_interrupt, gpio_get(_gpio_interrupt));
     }
-    rp2040_log("test_max77958_interrupt: after driving low GPIO%d. Current Value:%d\n", _gpio_interrupt, gpio_get(_gpio_interrupt));
+    rp2040_log_i("test_max77958_interrupt: after driving low GPIO%d. Current Value:%d\n", _gpio_interrupt, gpio_get(_gpio_interrupt));
     uint32_t i = 0;
     while (!test_max77958_completed){
         sleep_ms(10);
 	tight_loop_contents();
 	i++;
 	if (i > 1000){
-	    rp2040_log("ERROR: test_max77958_interrupt timed out\n");
+	    rp2040_log_w("ERROR: test_max77958_interrupt timed out\n");
 	}
     }
     gpio_set_dir(_gpio_interrupt, GPIO_IN);
@@ -853,7 +853,7 @@ void test_max77958_interrupt(){
     test_max77958_completed = false;
     set_interrupt_masks();
     test_max77958_interrupt_bool = false;
-    rp2040_log("test_max77958_interrupt: PASSED after %" PRIu32 " milliseconds.\n", i*10);
+    rp2040_log_i("test_max77958_interrupt: PASSED after %" PRIu32 " milliseconds.\n", i*10);
 }
 
 static int32_t max77958_test_response(){
@@ -864,7 +864,7 @@ static int32_t max77958_test_response(){
 void max77958_init(uint gpio_interrupt, queue_t* cq, queue_t* rq){
     _gpio_interrupt = gpio_interrupt;
 
-    rp2040_log("max77958 init started\n");
+    rp2040_log_i("max77958 init started\n");
     call_queue_ptr = cq;
     return_queue_ptr = rq;
     queue_init(&opcode_queue, sizeof(queue_entry_t), 16);
@@ -893,7 +893,7 @@ void max77958_init(uint gpio_interrupt, queue_t* cq, queue_t* rq){
     //opcode_queue_add(set_src_pdos, 0);
 
     opcode_queue_pop();
-    rp2040_log("max77958 init finished\n");
+    rp2040_log_i("max77958 init finished\n");
     on_ccstat_change();
 
 }
@@ -906,19 +906,19 @@ static bool opcode_queue_pop(){
     queue_entry_t entry;
     // if there is an entry in the opcode_queue, remove it and add it to the call_queue
     if (queue_try_remove(&opcode_queue, &entry)){
-	rp2040_log("Removed entry from opcode_queue. %d entries remaining\n", queue_get_level(&opcode_queue));
+	rp2040_log_d("Removed entry from opcode_queue. %d entries remaining\n", queue_get_level(&opcode_queue));
 	// if the call_queue is full, assert
 	if(queue_try_add(call_queue_ptr, &entry)){
-	    rp2040_log("added opcode entry to call_queue\n");
+	    rp2040_log_d("added opcode entry to call_queue\n");
 	    return true;
 	}else{
-	    rp2040_log("ERROR: opcode_queue_pop: call_queue full\n");
+	    rp2040_log_e("ERROR: opcode_queue_pop: call_queue full\n");
 	    return false;
 	}
     }
     // if there is no entry in the opcode_queue, return false
     else {
-	rp2040_log("opcode_queue_pop: opcode_queue empty\n");
+	rp2040_log_d("opcode_queue_pop: opcode_queue empty\n");
     	return false;
     }
 }
@@ -941,7 +941,7 @@ static int32_t customer_config_write(){
 
     // Convert config to register value using helper function
     send_buf[2] = max77958_build_customer_config_value(&config);
-    rp2040_log("customer_config_write config = 0b"
+    rp2040_log_d("customer_config_write config = 0b"
 	       BYTE_TO_BINARY_PATTERN "\n",
 	       BYTE_TO_BINARY(send_buf[2]));
 
@@ -1117,33 +1117,33 @@ static int32_t pd_msg_response(){
     send_buf[0] = REG_PD_STATUS0; // 0xE PD_STATUS0 Register 
     i2c_write_error_handling(i2c0, MAX77958_SLAVE_P1, send_buf, 1, true);
     i2c_read_error_handling(i2c0, MAX77958_SLAVE_P1, return_buf, 1, false);
-    rp2040_log("PD_STATUS0: 0x%02x\n", return_buf[0]);
+    rp2040_log_d("PD_STATUS0: 0x%02x\n", return_buf[0]);
     switch (return_buf[0]){
         case PDMSG_PRSWAP_SRCTOSWAP:
-	    rp2040_log("PD Message: PRSWAP_SRCTOSWAP\n");
+	    rp2040_log_d("PD Message: PRSWAP_SRCTOSWAP\n");
 	    break;
 	case PDMSG_PRSWAP_SWAPTOSNK:
-	    rp2040_log("PD Message: PRSWAP_SWAPTOSNK\n");
+	    rp2040_log_d("PD Message: PRSWAP_SWAPTOSNK\n");
 	    vbus_turn_off();
 	    break;
 	case PDMSG_PRSWAP_SNKTOSWAP:
-	    rp2040_log("PD Message: PRSWAP_SNKTOSWAP\n");
+	    rp2040_log_d("PD Message: PRSWAP_SNKTOSWAP\n");
 	    break;
 	case PDMSG_PRSWAP_SWAPTOSRC:
-	    rp2040_log("PD Message: PRSWAP_SWAPTOSRC\n");
+	    rp2040_log_d("PD Message: PRSWAP_SWAPTOSRC\n");
 	    vbus_turn_on();
 	    break;
 	case PDMSG_VDM_NAK_RECEIVED:
-	    rp2040_log("PD Message: VDM_NAK Received\n");
+	    rp2040_log_d("PD Message: VDM_NAK Received\n");
 	case PDMSG_VDM_BUSY_RECEIVED:
-	    rp2040_log("PD Message: VDM_BUSY_RECEIVED\n");
+	    rp2040_log_d("PD Message: VDM_BUSY_RECEIVED\n");
 	case PDMSG_VDM_ACK_RECEIVED:
-	    rp2040_log("PD Message: VDM_ACK_RECEIVED\n");
+	    rp2040_log_d("PD Message: VDM_ACK_RECEIVED\n");
 	case PDMSG_VDM_REQ_RECEIVED:
-	    rp2040_log("PD Message: VDM_REQ_RECEIVED\n");
+	    rp2040_log_d("PD Message: VDM_REQ_RECEIVED\n");
 	    break;
 	default:
-	    rp2040_log("PD Message: Unknown\n");
+	    rp2040_log_d("PD Message: Unknown\n");
 	    break;
 	}	
     return 0;
@@ -1157,7 +1157,7 @@ void max77958_shutdown(uint gpio_interrupt){
 	sleep_ms(100);
 	i++;
 	if (i > 10){
-	    rp2040_log("ERROR: Timed out waiting for GPIO to finish\n");
+	    rp2040_log_w("ERROR: Timed out waiting for GPIO to finish\n");
 	}
     }
 }

--- a/src/max77976.c
+++ b/src/max77976.c
@@ -255,13 +255,13 @@ uint32_t max77976_get_chg_details(){
     rp2040_log_d("CHG_DETAILS_00_CHGIN_DTLS: ");
     switch (CHGIN_DTLS){
         case 0b00:
-	    rp2040_log_d("VBUS is invalid. VCHGIN rising: VCHGIN < VCHGIN_UVLO. VCHGIN falling: VCHGIN < VCHGIN_REG (AICL)");
+	    rp2040_log_w("VBUS is invalid. VCHGIN rising: VCHGIN < VCHGIN_UVLO. VCHGIN falling: VCHGIN < VCHGIN_REG (AICL)");
 	    break;
         case 0b01:
-	    rp2040_log_d("VBUS is invalid. VCHGIN < VBATT + VCHGIN2SYS and VCHGIN > VCHGIN_UVLO");
+	    rp2040_log_w("VBUS is invalid. VCHGIN < VBATT + VCHGIN2SYS and VCHGIN > VCHGIN_UVLO");
 	    break;
         case 0b10:
-	    rp2040_log_d("VBUS is invalid. VCHGIN > VCHGIN_OVLO");
+	    rp2040_log_w("VBUS is invalid. VCHGIN > VCHGIN_OVLO");
 	    break;
         case 0b11:
 	    rp2040_log_d("VBUS is valid. VCHGIN > VCHGIN_UVLO and VCHGIN > VBATT + VCHGIN2SYS and VCHGIN < VCHGIN_OVLO");
@@ -281,7 +281,7 @@ uint32_t max77976_get_chg_details(){
 	    rp2040_log_d("The junction temperature is less than the threshold set by REGTEMP and the full charge current limit is available");
 	    break;
 	case 0b1:
-	    rp2040_log_d("The junction temperature is greater than the threshold set by REGTEMP and the charge current limit may be folding back to reduce power dissipation.");
+	    rp2040_log_w("The junction temperature is greater than the threshold set by REGTEMP and the charge current limit may be folding back to reduce power dissipation.");
 	    break;
     }
     rp2040_log_d("\n");
@@ -289,22 +289,22 @@ uint32_t max77976_get_chg_details(){
     rp2040_log_d("CHG_DETAILS_01_BAT_DTLS: ");
     switch (BAT_DTLS){
         case 0b000:
-	    rp2040_log_d("Battery Removal");
+	    rp2040_log_w("Battery Removal");
 	    break;
         case 0b001:
 	    rp2040_log_d("Battery Prequalification Voltage");
 	    break;
         case 0b010:
-	    rp2040_log_d("Battery Timer Fault");
+	    rp2040_log_w("Battery Timer Fault");
 	    break;
         case 0b011:
 	    rp2040_log_d("Battery Regular Voltage");
 	    break;
         case 0b100:
-	    rp2040_log_d("Battery Low Voltage");
+	    rp2040_log_w("Battery Low Voltage");
 	    break;
         case 0b101:
-	    rp2040_log_d("Battery Overvoltage");
+	    rp2040_log_w("Battery Overvoltage");
 	    break;
         case 0b110:
 	    rp2040_log_d("Reserved");
@@ -335,31 +335,31 @@ uint32_t max77976_get_chg_details(){
 	    rp2040_log_d("Reserved");
 	    break;
         case 0x06:
-	    rp2040_log_d("Charger is in timer-fault mode.");
+	    rp2040_log_w("Charger is in timer-fault mode.");
 	    break;
         case 0x07:
-	    rp2040_log_d("Charger is suspended because QBATT is disabled");
+	    rp2040_log_w("Charger is suspended because QBATT is disabled");
 	    break;
         case 0x08:
-	    rp2040_log_d("Charger is off, charger input invalid and/or charger is disabled.");
+	    rp2040_log_w("Charger is off, charger input invalid and/or charger is disabled.");
 	    break;
         case 0x09:
 	    rp2040_log_d("Reserved");
 	    break;
         case 0x0A:
-	    rp2040_log_d("Charger is off and the junction temperature is > TSHDN.");
+	    rp2040_log_w("Charger is off and the junction temperature is > TSHDN.");
 	    break;
         case 0x0B:
-	    rp2040_log_d("Charger is off because the watchdog timer expired");
+	    rp2040_log_w("Charger is off because the watchdog timer expired");
 	    break;
         case 0x0C:
-	    rp2040_log_d("Charger is suspended or charge current or voltage is reduced based on JEITA control.");
+	    rp2040_log_w("Charger is suspended or charge current or voltage is reduced based on JEITA control.");
 	    break;
         case 0x0D:
-	    rp2040_log_d("Charger is suspended because battery removal is detected on THM pin.");
+	    rp2040_log_w("Charger is suspended because battery removal is detected on THM pin.");
 	    break;
         case 0x0E:
-	    rp2040_log_d("Charger is suspended because SUSPEND pin is high.");
+	    rp2040_log_w("Charger is suspended because SUSPEND pin is high.");
 	    break;
         case 0x0F:
 	    rp2040_log_d("Reserved");

--- a/src/max77976.c
+++ b/src/max77976.c
@@ -60,23 +60,23 @@ static int32_t max77976_parse_interrupt_vals(){
     uint8_t BYP_I = 1 << 0;
 
     if (buf[0] & AICL_I){
-	rp2040_log("MAX77976: AICL_I interrupt detected.\n");
+	rp2040_log_d("MAX77976: AICL_I interrupt detected.\n");
         if (buf[2] & AICL_I){
-	    rp2040_log("MAX77976: AICL mode.\n");
+	    rp2040_log_d("MAX77976: AICL mode.\n");
 	}else {
-	    rp2040_log("MAX77976: AICL mode not detected.\n");
+	    rp2040_log_d("MAX77976: AICL mode not detected.\n");
         }
     }
     if (buf[0] & CHGIN_I){
-	rp2040_log("MAX77976: CHGIN_I interrupt detected.\n");
+	rp2040_log_d("MAX77976: CHGIN_I interrupt detected.\n");
         if (buf[2] & CHGIN_I){
-	    rp2040_log("MAX77976: CHGIN input is valid.\n");
+	    rp2040_log_d("MAX77976: CHGIN input is valid.\n");
             // Set Charge mode to default mode to Charge Buck while charging
             //buf[0] = MAX77976_REG_CHG_CNFG_00_ADDR;
             //buf[1] = MAX77976_REG_CHG_CNFG_00_MODE_CHARGE_BUCK;
             //i2c_write_error_handling(i2c1, MAX77976_ADDR, buf, 2, false);
 	}else {
-	    rp2040_log("MAX77976: CHGIN input is not valid.\n");
+	    rp2040_log_d("MAX77976: CHGIN input is not valid.\n");
             // Set mode to Battery-boot (flash) while no charger present
             //buf[0] = MAX77976_REG_CHG_CNFG_00_ADDR;
             //buf[1] = MAX77976_REG_CHG_CNFG_00_MODE_BATTERY_BOOST_FLASH;
@@ -84,43 +84,43 @@ static int32_t max77976_parse_interrupt_vals(){
         }
     }
     if (buf[0] & INLIM_I){
-	rp2040_log("MAX77976: INLIM_I interrupt detected.\n");
+	rp2040_log_d("MAX77976: INLIM_I interrupt detected.\n");
         if (buf[2] & INLIM_I){
-	    rp2040_log("MAX77976: The CHGIN input current has been reaching the current limit for at least 30ms.\n");
+	    rp2040_log_w("MAX77976: The CHGIN input current has been reaching the current limit for at least 30ms.\n");
         }else {
-	    rp2040_log("MAX77976: The CHGIN input current has not reached the current limit.\n");
+	    rp2040_log_d("MAX77976: The CHGIN input current has not reached the current limit.\n");
 	}
     }
     if (buf[0] & CHG_I){
-	rp2040_log("MAX77976: CHG_I interrupt detected.\n");
+	rp2040_log_d("MAX77976: CHG_I interrupt detected.\n");
         if (buf[2] & CHG_I){
-	    rp2040_log("MAX77976: The charger has suspended charging or TREG = 1.\n");
+	    rp2040_log_w("MAX77976: The charger has suspended charging or TREG = 1.\n");
         }else {
-	    rp2040_log("MAX77976: The charger is okay or the charger is off.\n");
+	    rp2040_log_d("MAX77976: The charger is okay or the charger is off.\n");
 	}
     }
     if (buf[0] & BAT_I){
-	rp2040_log("MAX77976: BAT_I interrupt detected.\n");
+	rp2040_log_d("MAX77976: BAT_I interrupt detected.\n");
         if (buf[2] & BAT_I){
-	    rp2040_log("MAX77976: The battery has an issue or the charger has been suspended.\n");
+	    rp2040_log_w("MAX77976: The battery has an issue or the charger has been suspended.\n");
         }else {
-	    rp2040_log("MAX77976: The battery is okay.\n");
+	    rp2040_log_d("MAX77976: The battery is okay.\n");
 	}
     }
     if (buf[0] & DISQBAT_I){
-	rp2040_log("MAX77976: DISQBAT_I interrupt detected.\n");
+	rp2040_log_d("MAX77976: DISQBAT_I interrupt detected.\n");
         if (buf[2] & DISQBAT_I){
-	    rp2040_log("MAX77976: DISQBAT is high and QBATT is disabled.\n");
+	    rp2040_log_w("MAX77976: DISQBAT is high and QBATT is disabled.\n");
         }else {
-	    rp2040_log("MAX77976: DISQBAT is low and QBATT is not disabled.\n");
+	    rp2040_log_d("MAX77976: DISQBAT is low and QBATT is not disabled.\n");
 	}
     }
     if (buf[0] & BYP_I){
-	rp2040_log("MAX77976: BYP_I interrupt detected.\n");
+	rp2040_log_d("MAX77976: BYP_I interrupt detected.\n");
         if (buf[2] & BYP_I){
-	    rp2040_log("MAX77976: Something powered by the bypass node has hit current limit.\n");
+	    rp2040_log_w("MAX77976: Something powered by the bypass node has hit current limit.\n");
         }else {
-	    rp2040_log("MAX77976: The bypass node is okay.\n");
+	    rp2040_log_d("MAX77976: The bypass node is okay.\n");
 	}
     }
     if (buf[0] == 0){
@@ -134,14 +134,14 @@ static void max77976_get_interrupt_vals(uint8_t* buf_ptr) {
     uint8_t addr = MAX77976_REG_CHG_INT; // 0x04 Register
     i2c_write_error_handling(i2c1, MAX77976_ADDR, &addr, 1, true);
     i2c_read_error_handling(i2c1, MAX77976_ADDR, buf_ptr, 3, false);
-    rp2040_log("MAX77976 interrupts vals: 0x10: 0x%02x, 0x11: 0x%02x, 0x12: 0x%02x\n", buf_ptr[0], buf_ptr[1], buf_ptr[2]);
+    rp2040_log_d("MAX77976 interrupts vals: 0x10: 0x%02x, 0x11: 0x%02x, 0x12: 0x%02x\n", buf_ptr[0], buf_ptr[1], buf_ptr[2]);
 }
 
 
 int max77976_init(uint gpio_interrupt, queue_t* cq, queue_t* rq){
     _gpio_interrupt = gpio_interrupt;
 
-    rp2040_log("max77976 init started\n");
+    rp2040_log_i("max77976 init started\n");
     call_queue_ptr = cq;
     return_queue_ptr = rq;
 
@@ -217,8 +217,8 @@ void max77976_log_current_limit(){
 
     uint8_t CHG_CC = return_buf[0] & 0x7F;
 
-    rp2040_log("CHGIN_ILIM: 0x%02x\n", CHGIN_ILIM);
-    rp2040_log("CHG_CC: 0x%02x\n", CHG_CC);
+    rp2040_log_d("CHGIN_ILIM: 0x%02x\n", CHGIN_ILIM);
+    rp2040_log_d("CHG_CC: 0x%02x\n", CHG_CC);
 }
 
 void max77976_toggle_led(){
@@ -251,22 +251,22 @@ uint32_t max77976_get_chg_details(){
     i2c_read_error_handling(i2c1, MAX77976_ADDR, return_buf, 1, false);
     uint8_t CHG_DETAILS_00 = return_buf[0];
     uint8_t CHGIN_DTLS = (CHG_DETAILS_00 & 0x60) >> 5;
-    rp2040_log("CHG_DETAILS_00: 0x%02x\n CHGIN_DTLS: 0x%02x\n", CHG_DETAILS_00, CHGIN_DTLS);
-    rp2040_log("CHG_DETAILS_00_CHGIN_DTLS: ");
+    rp2040_log_d("CHG_DETAILS_00: 0x%02x\n CHGIN_DTLS: 0x%02x\n", CHG_DETAILS_00, CHGIN_DTLS);
+    rp2040_log_d("CHG_DETAILS_00_CHGIN_DTLS: ");
     switch (CHGIN_DTLS){
         case 0b00:
-	    rp2040_log("VBUS is invalid. VCHGIN rising: VCHGIN < VCHGIN_UVLO. VCHGIN falling: VCHGIN < VCHGIN_REG (AICL)");
+	    rp2040_log_d("VBUS is invalid. VCHGIN rising: VCHGIN < VCHGIN_UVLO. VCHGIN falling: VCHGIN < VCHGIN_REG (AICL)");
 	    break;
         case 0b01:
-	    rp2040_log("VBUS is invalid. VCHGIN < VBATT + VCHGIN2SYS and VCHGIN > VCHGIN_UVLO");
+	    rp2040_log_d("VBUS is invalid. VCHGIN < VBATT + VCHGIN2SYS and VCHGIN > VCHGIN_UVLO");
 	    break;
         case 0b10:
-	    rp2040_log("VBUS is invalid. VCHGIN > VCHGIN_OVLO");
+	    rp2040_log_d("VBUS is invalid. VCHGIN > VCHGIN_OVLO");
 	    break;
         case 0b11:
-	    rp2040_log("VBUS is valid. VCHGIN > VCHGIN_UVLO and VCHGIN > VBATT + VCHGIN2SYS and VCHGIN < VCHGIN_OVLO");
+	    rp2040_log_d("VBUS is valid. VCHGIN > VCHGIN_UVLO and VCHGIN > VBATT + VCHGIN2SYS and VCHGIN < VCHGIN_OVLO");
 	    break;
-    }rp2040_log("\n"); 
+    }rp2040_log_d("\n");
     
     i2c_write_error_handling(i2c1, MAX77976_ADDR, &send_buf[1], 1, true);
     i2c_read_error_handling(i2c1, MAX77976_ADDR, return_buf, 1, false);
@@ -274,127 +274,127 @@ uint32_t max77976_get_chg_details(){
     uint8_t TREG = (CHG_DETAILS_01 & (1 << 7) ) >> 7;
     uint8_t BAT_DTLS = (CHG_DETAILS_01 & 0x70) >> 4;
     uint8_t CHG_DTLS = (CHG_DETAILS_01 & 0xF);
-    rp2040_log("CHG_DETAILS_01: 0x%02x\n TREG: 0x%02x\n BAT_DTLS: 0x%02x\n CHG_DTLS: 0x%02x\n", CHG_DETAILS_01, TREG, BAT_DTLS, CHG_DTLS);
-    rp2040_log("CHG_DETAILS_01_TREG: ");
+    rp2040_log_d("CHG_DETAILS_01: 0x%02x\n TREG: 0x%02x\n BAT_DTLS: 0x%02x\n CHG_DTLS: 0x%02x\n", CHG_DETAILS_01, TREG, BAT_DTLS, CHG_DTLS);
+    rp2040_log_d("CHG_DETAILS_01_TREG: ");
     switch (TREG){
         case 0b0:
-	    rp2040_log("The junction temperature is less than the threshold set by REGTEMP and the full charge current limit is available");
+	    rp2040_log_d("The junction temperature is less than the threshold set by REGTEMP and the full charge current limit is available");
 	    break;
 	case 0b1:
-	    rp2040_log("The junction temperature is greater than the threshold set by REGTEMP and the charge current limit may be folding back to reduce power dissipation.");
+	    rp2040_log_d("The junction temperature is greater than the threshold set by REGTEMP and the charge current limit may be folding back to reduce power dissipation.");
 	    break;
     }
-    rp2040_log("\n"); 
+    rp2040_log_d("\n");
 
-    rp2040_log("CHG_DETAILS_01_BAT_DTLS: ");
+    rp2040_log_d("CHG_DETAILS_01_BAT_DTLS: ");
     switch (BAT_DTLS){
         case 0b000:
-	    rp2040_log("Battery Removal");
+	    rp2040_log_d("Battery Removal");
 	    break;
         case 0b001:
-	    rp2040_log("Battery Prequalification Voltage");
+	    rp2040_log_d("Battery Prequalification Voltage");
 	    break;
         case 0b010:
-	    rp2040_log("Battery Timer Fault");
+	    rp2040_log_d("Battery Timer Fault");
 	    break;
         case 0b011:
-	    rp2040_log("Battery Regular Voltage");
+	    rp2040_log_d("Battery Regular Voltage");
 	    break;
         case 0b100:
-	    rp2040_log("Battery Low Voltage");
+	    rp2040_log_d("Battery Low Voltage");
 	    break;
         case 0b101:
-	    rp2040_log("Battery Overvoltage");
+	    rp2040_log_d("Battery Overvoltage");
 	    break;
         case 0b110:
-	    rp2040_log("Reserved");
+	    rp2040_log_d("Reserved");
 	    break;
         case 0b111:
-	    rp2040_log("Battery Only");
+	    rp2040_log_d("Battery Only");
 	    break;
-    }rp2040_log("\n"); 
+    }rp2040_log_d("\n");
     
-    rp2040_log("CHG_DETAILS_01_CHG_DTLS: ");
+    rp2040_log_d("CHG_DETAILS_01_CHG_DTLS: ");
     switch (CHG_DTLS){
         case 0x00:
-	    rp2040_log("Charger is in dead-battery prequalification or low-battery prequalification mode.");
+	    rp2040_log_d("Charger is in dead-battery prequalification or low-battery prequalification mode.");
 	    break;
         case 0x01:
-	    rp2040_log("Charger is in fast-charge constant current mode.");
+	    rp2040_log_d("Charger is in fast-charge constant current mode.");
 	    break;
         case 0x02:
-	    rp2040_log("Charger is in fast-charge constant voltage mode.");
+	    rp2040_log_d("Charger is in fast-charge constant voltage mode.");
 	    break;
         case 0x03:
-	    rp2040_log("Charger is in top-off mode.");
+	    rp2040_log_d("Charger is in top-off mode.");
 	    break;
         case 0x04:
-	    rp2040_log("Charger is in done mode.");
+	    rp2040_log_d("Charger is in done mode.");
 	    break;
         case 0x05:
-	    rp2040_log("Reserved");
+	    rp2040_log_d("Reserved");
 	    break;
         case 0x06:
-	    rp2040_log("Charger is in timer-fault mode.");
+	    rp2040_log_d("Charger is in timer-fault mode.");
 	    break;
         case 0x07:
-	    rp2040_log("Charger is suspended because QBATT is disabled");
+	    rp2040_log_d("Charger is suspended because QBATT is disabled");
 	    break;
         case 0x08:
-	    rp2040_log("Charger is off, charger input invalid and/or charger is disabled.");
+	    rp2040_log_d("Charger is off, charger input invalid and/or charger is disabled.");
 	    break;
         case 0x09:
-	    rp2040_log("Reserved");
+	    rp2040_log_d("Reserved");
 	    break;
         case 0x0A:
-	    rp2040_log("Charger is off and the junction temperature is > TSHDN.");
+	    rp2040_log_d("Charger is off and the junction temperature is > TSHDN.");
 	    break;
         case 0x0B:
-	    rp2040_log("Charger is off because the watchdog timer expired");
+	    rp2040_log_d("Charger is off because the watchdog timer expired");
 	    break;
         case 0x0C:
-	    rp2040_log("Charger is suspended or charge current or voltage is reduced based on JEITA control.");
+	    rp2040_log_d("Charger is suspended or charge current or voltage is reduced based on JEITA control.");
 	    break;
         case 0x0D:
-	    rp2040_log("Charger is suspended because battery removal is detected on THM pin.");
+	    rp2040_log_d("Charger is suspended because battery removal is detected on THM pin.");
 	    break;
         case 0x0E:
-	    rp2040_log("Charger is suspended because SUSPEND pin is high.");
+	    rp2040_log_d("Charger is suspended because SUSPEND pin is high.");
 	    break;
         case 0x0F:
-	    rp2040_log("Reserved");
+	    rp2040_log_d("Reserved");
 	    break;
-    }rp2040_log("\n"); 
+    }rp2040_log_d("\n");
     
     i2c_write_error_handling(i2c1, MAX77976_ADDR, &send_buf[2], 1, true);
     i2c_read_error_handling(i2c1, MAX77976_ADDR, return_buf, 1, false);
     uint8_t CHG_DETAILS_02 = return_buf[0];
     uint8_t THM_DTLS = (CHG_DETAILS_02 & 0x70) >> 4;
     uint8_t BYP_DTLS = (CHG_DETAILS_02 & 0x0F);
-    rp2040_log("CHG_DETAILS_02_BYP_DTLS: ");
+    rp2040_log_d("CHG_DETAILS_02_BYP_DTLS: ");
     switch (BYP_DTLS){
         case 0x00:
-	    rp2040_log("The bypass node is okay.");
+	    rp2040_log_d("The bypass node is okay.");
 	    break;
         case 0x01:
-	    rp2040_log("OTG_ILIM when CHG_CNFG_00.MODE=0xA or 0xE or 0xF");
+	    rp2040_log_d("OTG_ILIM when CHG_CNFG_00.MODE=0xA or 0xE or 0xF");
 	    break;
         case 0x02:
-	    rp2040_log("BSTILIM");
+	    rp2040_log_d("BSTILIM");
 	    break;
         case 0x04:
-	    rp2040_log("BCKNegILIM");
+	    rp2040_log_d("BCKNegILIM");
 	    break;
         case 0x08:
-	    rp2040_log("BST_SWON_DONE");
+	    rp2040_log_d("BST_SWON_DONE");
 	    break;
-    }rp2040_log("\n"); 
+    }rp2040_log_d("\n");
 
     i2c_write_error_handling(i2c1, MAX77976_ADDR, &send_buf[3], 1, true);
     i2c_read_error_handling(i2c1, MAX77976_ADDR, return_buf, 1, false);
     uint8_t CHG_CNFG_00 = return_buf[0];
     uint8_t _MODE = (CHG_CNFG_00 & 0x0F);
-    rp2040_log("CHG_CNFG_00: 0x%x\n", _MODE);
+    rp2040_log_d("CHG_CNFG_00: 0x%x\n", _MODE);
 
     // convert and store the 4 bytes from the send_buf into a new uint32_t var
     uint32_t CHG_CNFG = (send_buf[4] << 24) | (send_buf[5] << 16) | (send_buf[6] << 8) | (send_buf[7]);
@@ -433,7 +433,7 @@ static void max77976_set_interrupt_masks(){
 }
 
 void test_max77976_get_id(){
-    rp2040_log("test_max77976_get_id started...\n"); 
+    rp2040_log_i("test_max77976_get_id started...\n");
     max77976_set_interrupt_masks_all_masked();
     // Check if responding as i2c slave before trying to write to it
     uint8_t rxdata;
@@ -441,15 +441,15 @@ void test_max77976_get_id(){
     i2c_write_error_handling(i2c1, MAX77976_ADDR, 0x0, 1, true);
     i2c_read_error_handling(i2c1, MAX77976_ADDR, &rxdata, 1, false);
     if (rxdata != 0x76){
-	rp2040_log("MAX77976 not responding. Exiting.\n");
+	rp2040_log_e("MAX77976 not responding. Exiting.\n");
 	assert(false);
     }
     max77976_set_interrupt_masks();
-    rp2040_log("test_max77976_get_id PASSED. Read CHIP_ID %x.\n", rxdata);
+    rp2040_log_i("test_max77976_get_id PASSED. Read CHIP_ID %x.\n", rxdata);
 }
 
 void test_max77976_get_FSW(){
-    rp2040_log("test_max77976_get_FSW started...\n"); 
+    rp2040_log_i("test_max77976_get_FSW started...\n");
     max77976_set_interrupt_masks_all_masked();
     uint8_t rxdata;
 
@@ -457,11 +457,11 @@ void test_max77976_get_FSW(){
     i2c_write_error_handling(i2c1, MAX77976_ADDR, &reg, 1, true);
     i2c_read_error_handling(i2c1, MAX77976_ADDR, &rxdata, 1, false);
     if (rxdata != 0x0){
-	rp2040_log("MAX77976 FSW Not 0x0. Exiting.\n");
+	rp2040_log_e("MAX77976 FSW Not 0x0. Exiting.\n");
 	assert(false);
     }
     max77976_set_interrupt_masks();
-    rp2040_log("test_max77976_get_FSW PASSED. Read register 0x1E to be %x.\n", rxdata);
+    rp2040_log_i("test_max77976_get_FSW PASSED. Read register 0x1E to be %x.\n", rxdata);
 }
 
 static int32_t max77976_test_response(){
@@ -470,23 +470,23 @@ static int32_t max77976_test_response(){
 }
 
 void test_max77976_interrupt(){
-    rp2040_log("test_max77976_interrupt starting...\n");
+    rp2040_log_i("test_max77976_interrupt starting...\n");
     max77976_set_interrupt_masks_all_masked();
     test_max77976_started = true;
-    rp2040_log("test_max77976_interrupt: prior to driving low GPIO%d. Current Value:%d\n", _gpio_interrupt, gpio_get(_gpio_interrupt));
+    rp2040_log_i("test_max77976_interrupt: prior to driving low GPIO%d. Current Value:%d\n", _gpio_interrupt, gpio_get(_gpio_interrupt));
     gpio_set_dir(_gpio_interrupt, GPIO_OUT);
     if (gpio_get(_gpio_interrupt) != 0){
-	rp2040_log("test_max77976_interrupt: GPIO%d was not driven low. Current Value:%d\n", _gpio_interrupt, gpio_get(_gpio_interrupt));
+	rp2040_log_e("test_max77976_interrupt: GPIO%d was not driven low. Current Value:%d\n", _gpio_interrupt, gpio_get(_gpio_interrupt));
 	assert(false);
     }
-    rp2040_log("test_max77976_interrupt: after driving low GPIO%d. Current Value:%d\n", _gpio_interrupt, gpio_get(_gpio_interrupt));
+    rp2040_log_i("test_max77976_interrupt: after driving low GPIO%d. Current Value:%d\n", _gpio_interrupt, gpio_get(_gpio_interrupt));
     uint32_t i = 0;
     while (!test_max77976_completed){
         sleep_ms(10);
 	tight_loop_contents();
 	i++;
 	if (i > 1000){
-	    rp2040_log("test_max77976_interrupt timed out\n");
+	    rp2040_log_e("test_max77976_interrupt timed out\n");
 	    assert(false);
 	}
     }
@@ -496,5 +496,5 @@ void test_max77976_interrupt(){
     test_max77976_completed = false;
     max77976_set_interrupt_masks();
 
-    rp2040_log("test_max77976_interrupt: Passed after %" PRIu32 " milliseconds.\n", i*10);
+    rp2040_log_i("test_max77976_interrupt: Passed after %" PRIu32 " milliseconds.\n", i*10);
 }

--- a/src/max77976.c
+++ b/src/max77976.c
@@ -251,8 +251,8 @@ uint32_t max77976_get_chg_details(){
     i2c_read_error_handling(i2c1, MAX77976_ADDR, return_buf, 1, false);
     uint8_t CHG_DETAILS_00 = return_buf[0];
     uint8_t CHGIN_DTLS = (CHG_DETAILS_00 & 0x60) >> 5;
-    rp2040_log_d("CHG_DETAILS_00: 0x%02x\n CHGIN_DTLS: 0x%02x\n", CHG_DETAILS_00, CHGIN_DTLS);
-    rp2040_log_d("CHG_DETAILS_00_CHGIN_DTLS: ");
+    rp2040_log_w("CHG_DETAILS_00: 0x%02x\n CHGIN_DTLS: 0x%02x\n", CHG_DETAILS_00, CHGIN_DTLS);
+    rp2040_log_w("CHG_DETAILS_00_CHGIN_DTLS: ");
     switch (CHGIN_DTLS){
         case 0b00:
 	    rp2040_log_w("VBUS is invalid. VCHGIN rising: VCHGIN < VCHGIN_UVLO. VCHGIN falling: VCHGIN < VCHGIN_REG (AICL)");
@@ -266,7 +266,7 @@ uint32_t max77976_get_chg_details(){
         case 0b11:
 	    rp2040_log_d("VBUS is valid. VCHGIN > VCHGIN_UVLO and VCHGIN > VBATT + VCHGIN2SYS and VCHGIN < VCHGIN_OVLO");
 	    break;
-    }rp2040_log_d("\n");
+    }rp2040_log_w("\n");
     
     i2c_write_error_handling(i2c1, MAX77976_ADDR, &send_buf[1], 1, true);
     i2c_read_error_handling(i2c1, MAX77976_ADDR, return_buf, 1, false);
@@ -274,8 +274,8 @@ uint32_t max77976_get_chg_details(){
     uint8_t TREG = (CHG_DETAILS_01 & (1 << 7) ) >> 7;
     uint8_t BAT_DTLS = (CHG_DETAILS_01 & 0x70) >> 4;
     uint8_t CHG_DTLS = (CHG_DETAILS_01 & 0xF);
-    rp2040_log_d("CHG_DETAILS_01: 0x%02x\n TREG: 0x%02x\n BAT_DTLS: 0x%02x\n CHG_DTLS: 0x%02x\n", CHG_DETAILS_01, TREG, BAT_DTLS, CHG_DTLS);
-    rp2040_log_d("CHG_DETAILS_01_TREG: ");
+    rp2040_log_w("CHG_DETAILS_01: 0x%02x\n TREG: 0x%02x\n BAT_DTLS: 0x%02x\n CHG_DTLS: 0x%02x\n", CHG_DETAILS_01, TREG, BAT_DTLS, CHG_DTLS);
+    rp2040_log_w("CHG_DETAILS_01_TREG: ");
     switch (TREG){
         case 0b0:
 	    rp2040_log_d("The junction temperature is less than the threshold set by REGTEMP and the full charge current limit is available");
@@ -284,9 +284,9 @@ uint32_t max77976_get_chg_details(){
 	    rp2040_log_w("The junction temperature is greater than the threshold set by REGTEMP and the charge current limit may be folding back to reduce power dissipation.");
 	    break;
     }
-    rp2040_log_d("\n");
+    rp2040_log_w("\n");
 
-    rp2040_log_d("CHG_DETAILS_01_BAT_DTLS: ");
+    rp2040_log_w("CHG_DETAILS_01_BAT_DTLS: ");
     switch (BAT_DTLS){
         case 0b000:
 	    rp2040_log_w("Battery Removal");
@@ -312,9 +312,9 @@ uint32_t max77976_get_chg_details(){
         case 0b111:
 	    rp2040_log_d("Battery Only");
 	    break;
-    }rp2040_log_d("\n");
+    }rp2040_log_w("\n");
     
-    rp2040_log_d("CHG_DETAILS_01_CHG_DTLS: ");
+    rp2040_log_w("CHG_DETAILS_01_CHG_DTLS: ");
     switch (CHG_DTLS){
         case 0x00:
 	    rp2040_log_d("Charger is in dead-battery prequalification or low-battery prequalification mode.");
@@ -364,7 +364,7 @@ uint32_t max77976_get_chg_details(){
         case 0x0F:
 	    rp2040_log_d("Reserved");
 	    break;
-    }rp2040_log_d("\n");
+    }rp2040_log_w("\n");
     
     i2c_write_error_handling(i2c1, MAX77976_ADDR, &send_buf[2], 1, true);
     i2c_read_error_handling(i2c1, MAX77976_ADDR, return_buf, 1, false);

--- a/src/max77976.c
+++ b/src/max77976.c
@@ -251,8 +251,7 @@ uint32_t max77976_get_chg_details(){
     i2c_read_error_handling(i2c1, MAX77976_ADDR, return_buf, 1, false);
     uint8_t CHG_DETAILS_00 = return_buf[0];
     uint8_t CHGIN_DTLS = (CHG_DETAILS_00 & 0x60) >> 5;
-    rp2040_log_w("CHG_DETAILS_00: 0x%02x\n CHGIN_DTLS: 0x%02x\n", CHG_DETAILS_00, CHGIN_DTLS);
-    rp2040_log_w("CHG_DETAILS_00_CHGIN_DTLS: ");
+    rp2040_log_d("CHG_DETAILS_00: 0x%02x\n CHGIN_DTLS: 0x%02x\n", CHG_DETAILS_00, CHGIN_DTLS);
     switch (CHGIN_DTLS){
         case 0b00:
 	    rp2040_log_w("VBUS is invalid. VCHGIN rising: VCHGIN < VCHGIN_UVLO. VCHGIN falling: VCHGIN < VCHGIN_REG (AICL)");
@@ -266,7 +265,7 @@ uint32_t max77976_get_chg_details(){
         case 0b11:
 	    rp2040_log_d("VBUS is valid. VCHGIN > VCHGIN_UVLO and VCHGIN > VBATT + VCHGIN2SYS and VCHGIN < VCHGIN_OVLO");
 	    break;
-    }rp2040_log_w("\n");
+    }
     
     i2c_write_error_handling(i2c1, MAX77976_ADDR, &send_buf[1], 1, true);
     i2c_read_error_handling(i2c1, MAX77976_ADDR, return_buf, 1, false);
@@ -274,8 +273,7 @@ uint32_t max77976_get_chg_details(){
     uint8_t TREG = (CHG_DETAILS_01 & (1 << 7) ) >> 7;
     uint8_t BAT_DTLS = (CHG_DETAILS_01 & 0x70) >> 4;
     uint8_t CHG_DTLS = (CHG_DETAILS_01 & 0xF);
-    rp2040_log_w("CHG_DETAILS_01: 0x%02x\n TREG: 0x%02x\n BAT_DTLS: 0x%02x\n CHG_DTLS: 0x%02x\n", CHG_DETAILS_01, TREG, BAT_DTLS, CHG_DTLS);
-    rp2040_log_w("CHG_DETAILS_01_TREG: ");
+    rp2040_log_d("CHG_DETAILS_01: 0x%02x\n TREG: 0x%02x\n BAT_DTLS: 0x%02x\n CHG_DTLS: 0x%02x\n", CHG_DETAILS_01, TREG, BAT_DTLS, CHG_DTLS);
     switch (TREG){
         case 0b0:
 	    rp2040_log_d("The junction temperature is less than the threshold set by REGTEMP and the full charge current limit is available");
@@ -284,9 +282,7 @@ uint32_t max77976_get_chg_details(){
 	    rp2040_log_w("The junction temperature is greater than the threshold set by REGTEMP and the charge current limit may be folding back to reduce power dissipation.");
 	    break;
     }
-    rp2040_log_w("\n");
 
-    rp2040_log_w("CHG_DETAILS_01_BAT_DTLS: ");
     switch (BAT_DTLS){
         case 0b000:
 	    rp2040_log_w("Battery Removal");
@@ -312,9 +308,8 @@ uint32_t max77976_get_chg_details(){
         case 0b111:
 	    rp2040_log_d("Battery Only");
 	    break;
-    }rp2040_log_w("\n");
+    }
     
-    rp2040_log_w("CHG_DETAILS_01_CHG_DTLS: ");
     switch (CHG_DTLS){
         case 0x00:
 	    rp2040_log_d("Charger is in dead-battery prequalification or low-battery prequalification mode.");
@@ -364,14 +359,13 @@ uint32_t max77976_get_chg_details(){
         case 0x0F:
 	    rp2040_log_d("Reserved");
 	    break;
-    }rp2040_log_w("\n");
+    }
     
     i2c_write_error_handling(i2c1, MAX77976_ADDR, &send_buf[2], 1, true);
     i2c_read_error_handling(i2c1, MAX77976_ADDR, return_buf, 1, false);
     uint8_t CHG_DETAILS_02 = return_buf[0];
     uint8_t THM_DTLS = (CHG_DETAILS_02 & 0x70) >> 4;
     uint8_t BYP_DTLS = (CHG_DETAILS_02 & 0x0F);
-    rp2040_log_d("CHG_DETAILS_02_BYP_DTLS: ");
     switch (BYP_DTLS){
         case 0x00:
 	    rp2040_log_d("The bypass node is okay.");
@@ -388,7 +382,7 @@ uint32_t max77976_get_chg_details(){
         case 0x08:
 	    rp2040_log_d("BST_SWON_DONE");
 	    break;
-    }rp2040_log_d("\n");
+    }
 
     i2c_write_error_handling(i2c1, MAX77976_ADDR, &send_buf[3], 1, true);
     i2c_read_error_handling(i2c1, MAX77976_ADDR, return_buf, 1, false);

--- a/src/ncp3901.c
+++ b/src/ncp3901.c
@@ -49,14 +49,14 @@ void ncp3901_on_wireless_charger_interrupt(uint gpio, uint32_t event_mask)
 }
 
 static int32_t ncp3901_on_wireless_charger_attached(int32_t test){
-    rp2040_log("Wireless power available\n");
+    rp2040_log_d("Wireless power available\n");
     // send to Android to inform that wireless power available.
     wireless_charger_attached = true;
     return 0;
 }
 
 static int32_t ncp3901_on_wireless_charger_detached(int32_t test){
-    rp2040_log("Wireless power unavailable\n");
+    rp2040_log_d("Wireless power unavailable\n");
     // send to Android to inform that wireless power unavailable.
     wireless_charger_attached = false;
     return 0;
@@ -107,51 +107,51 @@ void ncp3901_shutdown(){
 }
 
 void test_ncp3901_interrupt(){
-    rp2040_log("test_ncp3901_interrupt: starting test of wireless connection...\n");
+    rp2040_log_i("test_ncp3901_interrupt: starting test of wireless connection...\n");
     test_ncp3901_started = true;
-    rp2040_log("test_ncp3901_interrupt: prior to driving low GPIO%d. Current Value:%d\n", _gpio_wireless_charger, gpio_get(_gpio_wireless_charger));
+    rp2040_log_i("test_ncp3901_interrupt: prior to driving low GPIO%d. Current Value:%d\n", _gpio_wireless_charger, gpio_get(_gpio_wireless_charger));
     gpio_set_dir(_gpio_wireless_charger, GPIO_OUT);
     if (gpio_get(_gpio_wireless_charger) != 0){
-	rp2040_log("ERROR: test_ncp3901_interrupt: GPIO%d was not driven low. Current Value:%d\n", _gpio_wireless_charger, gpio_get(_gpio_wireless_charger));
+	rp2040_log_e("ERROR: test_ncp3901_interrupt: GPIO%d was not driven low. Current Value:%d\n", _gpio_wireless_charger, gpio_get(_gpio_wireless_charger));
 	assert(false);
     }
-    rp2040_log("test_ncp3901_interrupt: after driving low GPIO%d. Current Value:%d\n", _gpio_wireless_charger, gpio_get(_gpio_wireless_charger));
+    rp2040_log_i("test_ncp3901_interrupt: after driving low GPIO%d. Current Value:%d\n", _gpio_wireless_charger, gpio_get(_gpio_wireless_charger));
     uint32_t i = 0;
     while (!test_ncp3901_completed){
         sleep_ms(10);
 	tight_loop_contents();
 	i++;
 	if (i > 1000){
-	    rp2040_log("ERROR: test_ncp3901_interrupt wireless connect timed out\n");
+	    rp2040_log_e("ERROR: test_ncp3901_interrupt wireless connect timed out\n");
 	    assert(false);
 	}
     }
     test_ncp3901_started = false;
     test_ncp3901_completed = false;
-    rp2040_log("test_ncp3901_interrupt_wireless_connect: PASSED after %" PRIu32 " milliseconds.\n", i*10);
+    rp2040_log_i("test_ncp3901_interrupt_wireless_connect: PASSED after %" PRIu32 " milliseconds.\n", i*10);
 
     // This should trigger the opposite interrupt EGDE_RISE
-    rp2040_log("test_ncp3901_interrupt: starting test of wireless disconnection...\n");
+    rp2040_log_i("test_ncp3901_interrupt: starting test of wireless disconnection...\n");
     test_ncp3901_started = true;
-    rp2040_log("test_ncp3901_interrupt: prior to pulling up GPIO%d. Current Value:%d\n", _gpio_wireless_charger, gpio_get(_gpio_wireless_charger));
+    rp2040_log_i("test_ncp3901_interrupt: prior to pulling up GPIO%d. Current Value:%d\n", _gpio_wireless_charger, gpio_get(_gpio_wireless_charger));
     gpio_set_dir(_gpio_wireless_charger, GPIO_IN);
     gpio_pull_up(_gpio_wireless_charger);
     if (gpio_get(_gpio_wireless_charger) != 1){
-	rp2040_log("ERROR: test_ncp3901_interrupt: GPIO%d was pulled up. Current Value:%d\n", _gpio_wireless_charger, gpio_get(_gpio_wireless_charger));
+	rp2040_log_e("ERROR: test_ncp3901_interrupt: GPIO%d was pulled up. Current Value:%d\n", _gpio_wireless_charger, gpio_get(_gpio_wireless_charger));
 	assert(false);
     }
-    rp2040_log("test_ncp3901_interrupt: after pulling up GPIO%d. Current Value:%d\n", _gpio_wireless_charger, gpio_get(_gpio_wireless_charger));
+    rp2040_log_i("test_ncp3901_interrupt: after pulling up GPIO%d. Current Value:%d\n", _gpio_wireless_charger, gpio_get(_gpio_wireless_charger));
     i = 0;
     while (!test_ncp3901_completed){
         sleep_ms(10);
 	tight_loop_contents();
 	i++;
 	if (i > 1000){
-	    rp2040_log("ERROR: test_ncp3901_interrupt wireless disconnect timed out\n");
+	    rp2040_log_e("ERROR: test_ncp3901_interrupt wireless disconnect timed out\n");
 	    assert(false);
 	}
     }
-    rp2040_log("test_ncp3901_interrupt_wireless_disconnect: PASSED after %" PRIu32 " milliseconds.\n", i*10);
+    rp2040_log_i("test_ncp3901_interrupt_wireless_disconnect: PASSED after %" PRIu32 " milliseconds.\n", i*10);
 }
 
 static int32_t ncp3901_test_response(){

--- a/src/quad_encoders.c
+++ b/src/quad_encoders.c
@@ -50,6 +50,6 @@ void quad_encoder_update(){
 	encoders[encoder].count_current = quadrature_encoder_get_count(pio, encoder);
 	encoders[encoder].count_delta = encoders[encoder].count_current - encoders[encoder].count_previous;
 	encoders[encoder].count_previous = encoders[encoder].count_current;
-        rp2040_log("Encoder %d: %" PRId32 ", delta: %" PRId32 "\n", encoder, encoders[encoder].count_current, encoders[encoder].count_delta);
+        rp2040_log_d("Encoder %d: %" PRId32 ", delta: %" PRId32 "\n", encoder, encoders[encoder].count_current, encoders[encoder].count_delta);
     }
 }

--- a/src/robot.c
+++ b/src/robot.c
@@ -195,8 +195,8 @@ void on_start(){
     gpio_set_function(LOG_UART_RX_PIN, GPIO_FUNC_UART);
     #endif
 
-    rp2040_log("=== FIRMWARE RESTART ===\n");
-    rp2040_log("on_start\n");
+    rp2040_log_i("=== FIRMWARE RESTART ===\n");
+    rp2040_log_i("on_start\n");
     stdio_init_all();
     stdio_set_translate_crlf(driver, false);
     gpio_set_irq_callback(&robot_interrupt_handler);
@@ -217,7 +217,7 @@ void on_start(){
     #endif
 
     sleep_ms(1000);
-    rp2040_log("done waiting 2\n");
+    rp2040_log_i("done waiting 2\n");
 
     #ifndef BOARD_PICO
     bq27742_g1_init(BQ27742_G1_INTERRUPT_PIN);
@@ -234,9 +234,9 @@ void on_start(){
     encoder_init(&call_queue);
     #endif
     
-    rp2040_log("encoders initialize. Waiting 1 second\n");
+    rp2040_log_d("encoders initialize. Waiting 1 second\n");
     sleep_ms(1000);
-    rp2040_log("done waiting, Running unit tests.\n");
+    rp2040_log_d("done waiting, Running unit tests.\n");
 
     #ifndef BOARD_PICO
     set_voltage(MOTOR_LEFT, 2.5);
@@ -247,7 +247,7 @@ void on_start(){
        i++;
        tight_loop_contents();
     }
-    rp2040_log("done counting, turning off motors\n");
+    rp2040_log_d("done counting, turning off motors\n");
     set_voltage(MOTOR_LEFT, 0);
     set_voltage(MOTOR_RIGHT, 0);
     robot_unit_tests();
@@ -277,7 +277,7 @@ void on_start(){
 }
 
 void robot_unit_tests(){
-    rp2040_log("----------Running robot unit tests-----------\n");
+    rp2040_log_i("----------Running robot unit tests-----------\n");
     test_max77958_get_id();
     test_max77958_status_block_read_all();
     test_max77958_bc_ctrl1_read();
@@ -296,11 +296,11 @@ void robot_unit_tests(){
     test_ncp3901_interrupt();
     test_drv8830_get_faults();
     test_drv8830_interrupt();
-    rp2040_log("-----------robot unit tests complete-----------\n");
+    rp2040_log_i("-----------robot unit tests complete-----------\n");
 }
 
 void on_shutdown(){
-    rp2040_log("Shutting down\n");
+    rp2040_log_i("Shutting down\n");
 
     #ifndef BOARD_PICO
     max77958_shutdown(MAX77958_INTB);
@@ -329,7 +329,7 @@ void free_queues(){
 	results_queue_pop();
     }
     while (!queue_is_empty(&call_queue)){
-    	rp2040_log("free_queues: call_queue not empty\n");
+        rp2040_log_i("free_queues: call_queue not empty\n");
     	sleep_ms(500);
     }
     queue_free(&call_queue);
@@ -339,7 +339,7 @@ void free_queues(){
 static void signal_stop_core1(){
     queue_entry_t stop_entry = {stop_core1, 0};
     if(!queue_try_add(&call_queue, &stop_entry)){
-	rp2040_log("ERROR: call_queue is full");
+	rp2040_log_e("ERROR: call_queue is full");
         assert(false);
     }
 }
@@ -452,7 +452,7 @@ void results_queue_try_add(void *func, int32_t arg){
     queue_entry_t entry = {func, arg};
     //rp2040_log("call_queue currently has %i entries\n", queue_get_level(&call_queue));
     if(!queue_try_add(&results_queue, &entry)){
-        rp2040_log("ERROR:results_queue is full");
+        rp2040_log_e("ERROR:results_queue is full");
 	assert(false);
     }
 }
@@ -461,7 +461,7 @@ void call_queue_try_add(entry_func func, int32_t arg){
     queue_entry_t entry = {func, arg};
     //rp2040_log("call_queue currently has %i entries\n", queue_get_level(&call_queue));
     if(!queue_try_add(&call_queue, &entry)){
-        rp2040_log("ERROR: call_queue is full");
+        rp2040_log_e("ERROR: call_queue is full");
 	assert(false);
     }
 }
@@ -492,7 +492,7 @@ void i2c_write_error_handling(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src,
         Throw(result);
     }
     Catch(e){
-	rp2040_log("ERROR: During i2c_write. Returned value of %i %i \n", result, e);
+	rp2040_log_e("ERROR: During i2c_write. Returned value of %i %i \n", result, e);
 	assert(false);
     }
 }
@@ -514,7 +514,7 @@ void i2c_read_error_handling(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t
        Throw(result);
     }
     Catch(e){
-	rp2040_log("ERROR: During i2c_read. Returned value of %i %i \n", result, e);
+	rp2040_log_e("ERROR: During i2c_read. Returned value of %i %i \n", result, e);
 	assert(false);
     }
 }

--- a/src/robot.c
+++ b/src/robot.c
@@ -264,7 +264,7 @@ void on_start(){
     read_reg(0xD);
     #endif
 
-    rp2040_log("on_start complete\n");
+    rp2040_log_i("on_start complete\n");
 #ifndef BOARD_PICO
 #ifdef DRV8830_SCOPE_TEST
     drv8830_scope_test_run();

--- a/src/rp2040_log.c
+++ b/src/rp2040_log.c
@@ -19,16 +19,10 @@
 static CircularBufferLog log_buffer;
 auto_init_mutex(rp2040_log_buffer_mutex);
 
-static bool rp2040_log_buffer_is_empty() {
-    return log_buffer.count == 0;
-}
-
 // Initialize the circular buffer
 void rp2040_log_init() {
-    memset(&log_buffer, 0, sizeof(log_buffer));
     log_buffer.head = 0; 
     log_buffer.tail = 0;
-    log_buffer.count = 0;
     
     #ifdef LOGGER_UART
     // Initialize dedicated UART for logging (separate from stdio)
@@ -47,18 +41,18 @@ void rp2040_log_release_lock() {
 }
 
 
-static void rp2040_log_v(int level, const char* format, va_list args) {
+void rp2040_log(int level, const char* format, ...) {
     if (level < LOG_LEVEL) return;
 
     rp2040_log_acquire_lock(); // Acquire the lock
+    va_list args;
 
     #ifdef LOGGER_UART
     // For UART mode, log directly to UART hardware (not stdio)
     char buffer[256];
-    va_list uart_args;
-    va_copy(uart_args, args);
-    vsnprintf(buffer, sizeof(buffer), format, uart_args);
-    va_end(uart_args);
+    va_start(args, format);
+    vsnprintf(buffer, sizeof(buffer), format, args);
+    va_end(args);
     
     // Send directly to UART0 on GPIO16/17
     uart_puts(LOG_UART, buffer);
@@ -66,11 +60,10 @@ static void rp2040_log_v(int level, const char* format, va_list args) {
     return;
     #endif
 
+    va_start(args, format);
     // Calculate the number of characters required
-    va_list size_args;
-    va_copy(size_args, args);
-    int len = vsnprintf(NULL, 0, format, size_args) + 1; //include the /n
-    va_end(size_args);
+    int len = vsnprintf(NULL, 0, format, args) + 1; //include the /n
+    va_end(args);
 
     // truncate the message if it is too long else expect chaos when overwriting unknown areas of memory
     if (len > LOG_BUFFER_CHAR_LIMIT) {
@@ -79,67 +72,35 @@ static void rp2040_log_v(int level, const char* format, va_list args) {
 
 
     // Format the message and copy it to the buffer, handling wrapping
-    va_list format_args;
-    va_copy(format_args, args);
-    vsnprintf(log_buffer.log_array[log_buffer.tail], len, format, format_args);
-    va_end(format_args);
+    va_start(args, format); // Restart the argument list
+    vsnprintf(log_buffer.log_array[log_buffer.tail], len, format, args);
+    va_end(args);
 
     log_buffer.log_array_line_size[log_buffer.tail] = len; // store the size of the line -2 for removing \n and null terminator
-    if (log_buffer.count == LOG_BUFFER_LINE_COUNT) {
+    // update head
+    if (log_buffer.tail == log_buffer.head) {
         log_buffer.head = (log_buffer.head + 1) % LOG_BUFFER_LINE_COUNT;
-    } else {
-        log_buffer.count++;
     }
     log_buffer.tail = (log_buffer.tail + 1) % LOG_BUFFER_LINE_COUNT; // Update tail correctly
 
     rp2040_log_release_lock(); // Release the lock
 }
 
-void rp2040_log(int level, const char* format, ...) {
-    va_list args;
-    va_start(args, format);
-    rp2040_log_v(level, format, args);
-    va_end(args);
-}
-
 // Function to retrieve the total number of bytes within the log_array
 uint16_t rp2040_get_byte_count() {
-   // Sum only populated entries within the live ring segment.
-   uint16_t byte_count = 0;
-   if (rp2040_log_buffer_is_empty()) {
-       return 0;
+   // sum up the values witin log_array_line_size
+   uint16_t byte_count = 0; 
+   for (int i = 0; i < LOG_BUFFER_LINE_COUNT; i++) {
+	   byte_count += log_buffer.log_array_line_size[i] - 1;
    }
-
-   uint16_t index = log_buffer.head;
-   for (uint16_t i = 0; i < log_buffer.count; i++) {
-       uint16_t line_size = log_buffer.log_array_line_size[index];
-       if (line_size > 0) {
-           byte_count += line_size - 1;
-       }
-       index = (index + 1) % LOG_BUFFER_LINE_COUNT;
-   }
-
    return byte_count;
 }
 
 void rp2040_log_flush(){
-    if (rp2040_log_buffer_is_empty()) {
-        return;
+    // printf each line within the log_array starting at the head
+    for (int i = 0; i < LOG_BUFFER_LINE_COUNT; i++) {
+	// only print up to log_array_line_size
+	printf("%.*s", log_buffer.log_array_line_size[log_buffer.head], log_buffer.log_array[log_buffer.head]);
+	log_buffer.head = (log_buffer.head + 1) % LOG_BUFFER_LINE_COUNT; // Update head correctly
     }
-
-    // Print only populated entries within the live ring segment.
-    uint16_t index = log_buffer.head;
-    for (uint16_t i = 0; i < log_buffer.count; i++) {
-        uint16_t line_size = log_buffer.log_array_line_size[index];
-        if (line_size > 0) {
-            printf("%.*s", line_size, log_buffer.log_array[index]);
-        }
-        index = (index + 1) % LOG_BUFFER_LINE_COUNT;
-    }
-
-    // Drain the buffer so the next GET_LOG only reports new entries.
-    log_buffer.head = 0;
-    log_buffer.tail = 0;
-    log_buffer.count = 0;
 }
-

--- a/src/rp2040_log.c
+++ b/src/rp2040_log.c
@@ -16,14 +16,19 @@
 #endif
 #define LOG_UART_TX_PIN PICO_DEFAULT_UART_TX_PIN
 #define LOG_UART_RX_PIN PICO_DEFAULT_UART_RX_PIN
-
 static CircularBufferLog log_buffer;
 auto_init_mutex(rp2040_log_buffer_mutex);
 
+static bool rp2040_log_buffer_is_empty() {
+    return log_buffer.count == 0;
+}
+
 // Initialize the circular buffer
 void rp2040_log_init() {
+    memset(&log_buffer, 0, sizeof(log_buffer));
     log_buffer.head = 0; 
     log_buffer.tail = 0;
+    log_buffer.count = 0;
     
     #ifdef LOGGER_UART
     // Initialize dedicated UART for logging (separate from stdio)
@@ -42,16 +47,18 @@ void rp2040_log_release_lock() {
 }
 
 
-void rp2040_log(const char* format, ...) {
+static void rp2040_log_v(int level, const char* format, va_list args) {
+    if (level < LOG_LEVEL) return;
+
     rp2040_log_acquire_lock(); // Acquire the lock
-    va_list args;
 
     #ifdef LOGGER_UART
     // For UART mode, log directly to UART hardware (not stdio)
     char buffer[256];
-    va_start(args, format);
-    vsnprintf(buffer, sizeof(buffer), format, args);
-    va_end(args);
+    va_list uart_args;
+    va_copy(uart_args, args);
+    vsnprintf(buffer, sizeof(buffer), format, uart_args);
+    va_end(uart_args);
     
     // Send directly to UART0 on GPIO16/17
     uart_puts(LOG_UART, buffer);
@@ -59,10 +66,11 @@ void rp2040_log(const char* format, ...) {
     return;
     #endif
 
-    va_start(args, format);
     // Calculate the number of characters required
-    int len = vsnprintf(NULL, 0, format, args) + 1; //include the /n 
-    va_end(args);
+    va_list size_args;
+    va_copy(size_args, args);
+    int len = vsnprintf(NULL, 0, format, size_args) + 1; //include the /n
+    va_end(size_args);
 
     // truncate the message if it is too long else expect chaos when overwriting unknown areas of memory
     if (len > LOG_BUFFER_CHAR_LIMIT) {
@@ -71,36 +79,67 @@ void rp2040_log(const char* format, ...) {
 
 
     // Format the message and copy it to the buffer, handling wrapping
-    va_start(args, format); // Restart the argument list
-    vsnprintf(log_buffer.log_array[log_buffer.tail], len, format, args);
-    va_end(args);
+    va_list format_args;
+    va_copy(format_args, args);
+    vsnprintf(log_buffer.log_array[log_buffer.tail], len, format, format_args);
+    va_end(format_args);
 
     log_buffer.log_array_line_size[log_buffer.tail] = len; // store the size of the line -2 for removing \n and null terminator
-    // update head
-    if (log_buffer.tail == log_buffer.head) {
+    if (log_buffer.count == LOG_BUFFER_LINE_COUNT) {
         log_buffer.head = (log_buffer.head + 1) % LOG_BUFFER_LINE_COUNT;
+    } else {
+        log_buffer.count++;
     }
     log_buffer.tail = (log_buffer.tail + 1) % LOG_BUFFER_LINE_COUNT; // Update tail correctly
 
     rp2040_log_release_lock(); // Release the lock
 }
 
+void rp2040_log(int level, const char* format, ...) {
+    va_list args;
+    va_start(args, format);
+    rp2040_log_v(level, format, args);
+    va_end(args);
+}
+
 // Function to retrieve the total number of bytes within the log_array
 uint16_t rp2040_get_byte_count() {
-   // sum up the values witin log_array_line_size
-   uint16_t byte_count = 0; 
-   for (int i = 0; i < LOG_BUFFER_LINE_COUNT; i++) {
-	   byte_count += log_buffer.log_array_line_size[i] - 1;
+   // Sum only populated entries within the live ring segment.
+   uint16_t byte_count = 0;
+   if (rp2040_log_buffer_is_empty()) {
+       return 0;
    }
+
+   uint16_t index = log_buffer.head;
+   for (uint16_t i = 0; i < log_buffer.count; i++) {
+       uint16_t line_size = log_buffer.log_array_line_size[index];
+       if (line_size > 0) {
+           byte_count += line_size - 1;
+       }
+       index = (index + 1) % LOG_BUFFER_LINE_COUNT;
+   }
+
    return byte_count;
 }
 
 void rp2040_log_flush(){
-    // printf each line within the log_array starting at the head
-    for (int i = 0; i < LOG_BUFFER_LINE_COUNT; i++) {
-	// only print up to log_array_line_size
-	printf("%.*s", log_buffer.log_array_line_size[log_buffer.head], log_buffer.log_array[log_buffer.head]);
-	log_buffer.head = (log_buffer.head + 1) % LOG_BUFFER_LINE_COUNT; // Update head correctly
+    if (rp2040_log_buffer_is_empty()) {
+        return;
     }
+
+    // Print only populated entries within the live ring segment.
+    uint16_t index = log_buffer.head;
+    for (uint16_t i = 0; i < log_buffer.count; i++) {
+        uint16_t line_size = log_buffer.log_array_line_size[index];
+        if (line_size > 0) {
+            printf("%.*s", line_size, log_buffer.log_array[index]);
+        }
+        index = (index + 1) % LOG_BUFFER_LINE_COUNT;
+    }
+
+    // Drain the buffer so the next GET_LOG only reports new entries.
+    log_buffer.head = 0;
+    log_buffer.tail = 0;
+    log_buffer.count = 0;
 }
 

--- a/src/rp2040_log.c
+++ b/src/rp2040_log.c
@@ -91,7 +91,9 @@ uint16_t rp2040_get_byte_count() {
    // sum up the values witin log_array_line_size
    uint16_t byte_count = 0; 
    for (int i = 0; i < LOG_BUFFER_LINE_COUNT; i++) {
-	   byte_count += log_buffer.log_array_line_size[i] - 1;
+	   if (log_buffer.log_array_line_size[i] > 0) {
+	       byte_count += log_buffer.log_array_line_size[i] - 1;
+	   }
    }
    return byte_count;
 }

--- a/src/serial_comm_manager.c
+++ b/src/serial_comm_manager.c
@@ -68,7 +68,7 @@ void get_block() {
     	    	    buffer_index++;
     	        }
     	    }else {
-    	        rp2040_log("Timeout while reading packet. Resetting state.\n");
+                rp2040_log_w("Timeout while reading packet. Resetting state.\n");
                 reset_packet_and_send_nack(&start_idx, &end_idx, &buffer_index);
                 return;
 	    }
@@ -87,12 +87,12 @@ void get_block() {
                 buffer_index = 0;
                 // Reset the packet
                 memset(&incoming_packet_from_android, 0, sizeof(IncomingPacketFromAndroid)); } else {
-                rp2040_log("Received incomplete packet. Resetting state.\n");
+                rp2040_log_w("Received incomplete packet. Resetting state.\n");
                 reset_packet_and_send_nack(&start_idx, &end_idx, &buffer_index);
                 return;
             }
         }else{
-            rp2040_log("Received packet with no end marker. Resetting state.\n");
+            rp2040_log_w("Received packet with no end marker. Resetting state.\n");
             reset_packet_and_send_nack(&start_idx, &end_idx, &buffer_index);
             return;
         }


### PR DESCRIPTION
## Summary
- What is in scope for this PR?
Adding several verbosity levels for logging. Context - 

> Current logging is controlled mostly by transport choices such as LOGGER=UART or LOGGER=USB, and many rp2040_log() calls remain compiled into normal builds. During USB-PD debugging, detailed logs were useful, but release firmware should avoid unnecessary formatting, UART/USB output, mutex contention, and timing perturbation.

> This should not be a MAX77958-specific flag. The logging policy should apply consistently across the firmware.
> 
> Desired behavior
> Debug builds can enable detailed state/action logs.
> Release builds can compile out verbose logs across all modules.
> Important fault/error logs can remain available through a separate severity level or build policy.
> Logging transport selection should remain separate from log verbosity and compile-time inclusion.

## Branching
- Milestone base branch: `main`
- This PR branch: `log-levels`

## Scope Declaration
- Related sibling PRs/issues (remaining slices), if any:
  - #29
