### PR TITLE
Stabilize MAX77958 role control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,13 @@ Change scope and safety
 - Treat dependency wiring, Docker setup, and debug/flash flows as shared repo infrastructure. Do not change them unless the task requires it.
 - Keep third-party dependency management consistent with the repository’s submodule-based model under `include/`.
 
+Firmware debugging expectations
+- For MAX77958, USB-PD, startup tests, UART logging, queue handling, and interrupt-driven behavior, analyze the state machine and shared wait/interrupt paths before proposing changes.
+- Treat a failing test, log line, or event as a reproducer for the underlying firmware issue until proven otherwise.
+- Do not hide, gate, skip, or weaken startup tests unless explicitly instructed.
+- Prefer bounded waits with diagnostics and shared recovery paths over blocking polls or per-test workarounds.
+- Keep debug logging useful, but do not block normal init or `on_start` behavior.
+
 PR review workflows
 - `codex-review` and `codex-reply` policy lives in `docs/codex-review-policy.md`.
 - Milestone-specific review guidance lives under `docs/milestones/`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ if(NOT (LOGGER STREQUAL "USB" OR LOGGER STREQUAL "UART"))
 endif()
 option(EXTERNAL_MAX77958_TEST "Probe an external MAX77958 on I2C1 and skip normal board bring-up" OFF)
 option(MAX77958_FORCE_VBUS_DIAGNOSTIC "Force MAX77958 GPIO4/GPIO5 high for VBUS diagnostics" OFF)
+set(MAX77958_DIAG_POLL_MS "2000" CACHE STRING "MAX77958 UART diagnostic poll duration in milliseconds")
 
 # Enable colored output
 set(CMAKE_COLOR_MAKEFILE ON)
@@ -95,6 +96,8 @@ endif()
 if(MAX77958_FORCE_VBUS_DIAGNOSTIC)
     target_compile_definitions(robot PUBLIC MAX77958_FORCE_VBUS_DIAGNOSTIC=1)
 endif()
+
+target_compile_definitions(robot PUBLIC MAX77958_DIAG_POLL_MS=${MAX77958_DIAG_POLL_MS})
 
 # Add the standard library to the build
 target_link_libraries(robot pico_stdlib pico_multicore hardware_pwm)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LOGGER "USB" CACHE STRING "Logging interface")
 if(NOT (LOGGER STREQUAL "USB" OR LOGGER STREQUAL "UART"))
   message(FATAL_ERROR "invalid logging interface: ${LOGGER}")
 endif()
+option(EXTERNAL_MAX77958_TEST "Probe an external MAX77958 on I2C1 and skip normal board bring-up" OFF)
 
 # Enable colored output
 set(CMAKE_COLOR_MAKEFILE ON)
@@ -84,6 +85,10 @@ pico_enable_stdio_usb(robot 1)
 
 if(LOGGER STREQUAL "UART")
     target_compile_definitions(robot PUBLIC LOGGER_UART=1)
+endif()
+
+if(EXTERNAL_MAX77958_TEST)
+    target_compile_definitions(robot PUBLIC EXTERNAL_MAX77958_TEST=1)
 endif()
 
 # Add the standard library to the build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,6 @@ if(NOT (LOGGER STREQUAL "USB" OR LOGGER STREQUAL "UART"))
 endif()
 option(EXTERNAL_MAX77958_TEST "Probe an external MAX77958 on I2C1 and skip normal board bring-up" OFF)
 option(MAX77958_FORCE_VBUS_DIAGNOSTIC "Force MAX77958 GPIO4/GPIO5 high for VBUS diagnostics" OFF)
-set(MAX77958_DIAG_POLL_MS "2000" CACHE STRING "MAX77958 UART diagnostic poll duration in milliseconds")
 
 # Enable colored output
 set(CMAKE_COLOR_MAKEFILE ON)
@@ -96,8 +95,6 @@ endif()
 if(MAX77958_FORCE_VBUS_DIAGNOSTIC)
     target_compile_definitions(robot PUBLIC MAX77958_FORCE_VBUS_DIAGNOSTIC=1)
 endif()
-
-target_compile_definitions(robot PUBLIC MAX77958_DIAG_POLL_MS=${MAX77958_DIAG_POLL_MS})
 
 # Add the standard library to the build
 target_link_libraries(robot pico_stdlib pico_multicore hardware_pwm)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ if(NOT (LOGGER STREQUAL "USB" OR LOGGER STREQUAL "UART"))
   message(FATAL_ERROR "invalid logging interface: ${LOGGER}")
 endif()
 option(EXTERNAL_MAX77958_TEST "Probe an external MAX77958 on I2C1 and skip normal board bring-up" OFF)
+option(MAX77958_FORCE_VBUS_DIAGNOSTIC "Force MAX77958 GPIO4/GPIO5 high for VBUS diagnostics" OFF)
 
 # Enable colored output
 set(CMAKE_COLOR_MAKEFILE ON)
@@ -89,6 +90,10 @@ endif()
 
 if(EXTERNAL_MAX77958_TEST)
     target_compile_definitions(robot PUBLIC EXTERNAL_MAX77958_TEST=1)
+endif()
+
+if(MAX77958_FORCE_VBUS_DIAGNOSTIC)
+    target_compile_definitions(robot PUBLIC MAX77958_FORCE_VBUS_DIAGNOSTIC=1)
 endif()
 
 # Add the standard library to the build

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ ARCH ?= amd64
 LOGGER ?= USB
 EXTERNAL_MAX77958_TEST ?= 0
 MAX77958_FORCE_VBUS_DIAGNOSTIC ?= 0
-MAX77958_DIAG_POLL_MS ?= 2000
 
 #  MILESTONE 1: BOARD SELECTION & VALIDATION 
 BOARD ?= customPCB
@@ -79,14 +78,13 @@ help:
 	@echo "  LOGGER=USB|UART         - Specify logger interface (default: USB)"
 	@echo "  EXTERNAL_MAX77958_TEST=0|1 - Probe external MAX77958 on I2C1 and skip normal board bring-up"
 	@echo "  MAX77958_FORCE_VBUS_DIAGNOSTIC=0|1 - Force MAX77958 GPIO4/GPIO5 high for VBUS diagnostics"
-	@echo "  MAX77958_DIAG_POLL_MS=N - UART MAX77958 status poll duration in milliseconds (default: 2000)"
 	@echo "  Example: make flash DOCKER_USB_DEVICE=/dev/ttyACM0"
 
 # Build firmware
 .PHONY: firmware
 firmware:
 	@echo "Building firmware in Docker with $(JOBS) jobs..."
-	$(DOCKER_RUN) bash -c "rm -rf build && mkdir build && cd build && cmake .. -DLOGGER=$(LOGGER) -DEXTERNAL_MAX77958_TEST=$(EXTERNAL_MAX77958_TEST) -DMAX77958_FORCE_VBUS_DIAGNOSTIC=$(MAX77958_FORCE_VBUS_DIAGNOSTIC) -DMAX77958_DIAG_POLL_MS=$(MAX77958_DIAG_POLL_MS) $(BOARD_FLAGS) && make -j$(JOBS)"
+	$(DOCKER_RUN) bash -c "rm -rf build && mkdir build && cd build && cmake .. -DLOGGER=$(LOGGER) -DEXTERNAL_MAX77958_TEST=$(EXTERNAL_MAX77958_TEST) -DMAX77958_FORCE_VBUS_DIAGNOSTIC=$(MAX77958_FORCE_VBUS_DIAGNOSTIC) $(BOARD_FLAGS) && make -j$(JOBS)"
 
 # Name for the persistent debug container
 DEBUG_CONTAINER := smartphone-robot-debug

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ JOBS ?= $(shell nproc)
 DOCKER_DEBUG_CONTAINER := smartphone-robot-debug
 ARCH ?= amd64
 LOGGER ?= USB
+EXTERNAL_MAX77958_TEST ?= 0
 
 #  MILESTONE 1: BOARD SELECTION & VALIDATION 
 BOARD ?= customPCB
@@ -74,13 +75,14 @@ help:
 	@echo "  JOBS=N                - Number of parallel build jobs (default: The number of processor cores)"
 	@echo "  ARCH=amd64|arm64        - Specify architecture for all make targets (default: amd64)"
 	@echo "  LOGGER=USB|UART         - Specify logger interface (default: USB)"
+	@echo "  EXTERNAL_MAX77958_TEST=0|1 - Probe external MAX77958 on I2C1 and skip normal board bring-up"
 	@echo "  Example: make flash DOCKER_USB_DEVICE=/dev/ttyACM0"
 
 # Build firmware
 .PHONY: firmware
 firmware:
 	@echo "Building firmware in Docker with $(JOBS) jobs..."
-	$(DOCKER_RUN) bash -c "rm -rf build && mkdir build && cd build && cmake .. -DLOGGER=$(LOGGER) $(BOARD_FLAGS) && make -j$(JOBS)"
+	$(DOCKER_RUN) bash -c "rm -rf build && mkdir build && cd build && cmake .. -DLOGGER=$(LOGGER) -DEXTERNAL_MAX77958_TEST=$(EXTERNAL_MAX77958_TEST) $(BOARD_FLAGS) && make -j$(JOBS)"
 
 # Name for the persistent debug container
 DEBUG_CONTAINER := smartphone-robot-debug

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ ARCH ?= amd64
 LOGGER ?= USB
 EXTERNAL_MAX77958_TEST ?= 0
 MAX77958_FORCE_VBUS_DIAGNOSTIC ?= 0
+MAX77958_DIAG_POLL_MS ?= 2000
 
 #  MILESTONE 1: BOARD SELECTION & VALIDATION 
 BOARD ?= customPCB
@@ -78,13 +79,14 @@ help:
 	@echo "  LOGGER=USB|UART         - Specify logger interface (default: USB)"
 	@echo "  EXTERNAL_MAX77958_TEST=0|1 - Probe external MAX77958 on I2C1 and skip normal board bring-up"
 	@echo "  MAX77958_FORCE_VBUS_DIAGNOSTIC=0|1 - Force MAX77958 GPIO4/GPIO5 high for VBUS diagnostics"
+	@echo "  MAX77958_DIAG_POLL_MS=N - UART MAX77958 status poll duration in milliseconds (default: 2000)"
 	@echo "  Example: make flash DOCKER_USB_DEVICE=/dev/ttyACM0"
 
 # Build firmware
 .PHONY: firmware
 firmware:
 	@echo "Building firmware in Docker with $(JOBS) jobs..."
-	$(DOCKER_RUN) bash -c "rm -rf build && mkdir build && cd build && cmake .. -DLOGGER=$(LOGGER) -DEXTERNAL_MAX77958_TEST=$(EXTERNAL_MAX77958_TEST) -DMAX77958_FORCE_VBUS_DIAGNOSTIC=$(MAX77958_FORCE_VBUS_DIAGNOSTIC) $(BOARD_FLAGS) && make -j$(JOBS)"
+	$(DOCKER_RUN) bash -c "rm -rf build && mkdir build && cd build && cmake .. -DLOGGER=$(LOGGER) -DEXTERNAL_MAX77958_TEST=$(EXTERNAL_MAX77958_TEST) -DMAX77958_FORCE_VBUS_DIAGNOSTIC=$(MAX77958_FORCE_VBUS_DIAGNOSTIC) -DMAX77958_DIAG_POLL_MS=$(MAX77958_DIAG_POLL_MS) $(BOARD_FLAGS) && make -j$(JOBS)"
 
 # Name for the persistent debug container
 DEBUG_CONTAINER := smartphone-robot-debug

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ DOCKER_DEBUG_CONTAINER := smartphone-robot-debug
 ARCH ?= amd64
 LOGGER ?= USB
 EXTERNAL_MAX77958_TEST ?= 0
+MAX77958_FORCE_VBUS_DIAGNOSTIC ?= 0
 
 #  MILESTONE 1: BOARD SELECTION & VALIDATION 
 BOARD ?= customPCB
@@ -76,13 +77,14 @@ help:
 	@echo "  ARCH=amd64|arm64        - Specify architecture for all make targets (default: amd64)"
 	@echo "  LOGGER=USB|UART         - Specify logger interface (default: USB)"
 	@echo "  EXTERNAL_MAX77958_TEST=0|1 - Probe external MAX77958 on I2C1 and skip normal board bring-up"
+	@echo "  MAX77958_FORCE_VBUS_DIAGNOSTIC=0|1 - Force MAX77958 GPIO4/GPIO5 high for VBUS diagnostics"
 	@echo "  Example: make flash DOCKER_USB_DEVICE=/dev/ttyACM0"
 
 # Build firmware
 .PHONY: firmware
 firmware:
 	@echo "Building firmware in Docker with $(JOBS) jobs..."
-	$(DOCKER_RUN) bash -c "rm -rf build && mkdir build && cd build && cmake .. -DLOGGER=$(LOGGER) -DEXTERNAL_MAX77958_TEST=$(EXTERNAL_MAX77958_TEST) $(BOARD_FLAGS) && make -j$(JOBS)"
+	$(DOCKER_RUN) bash -c "rm -rf build && mkdir build && cd build && cmake .. -DLOGGER=$(LOGGER) -DEXTERNAL_MAX77958_TEST=$(EXTERNAL_MAX77958_TEST) -DMAX77958_FORCE_VBUS_DIAGNOSTIC=$(MAX77958_FORCE_VBUS_DIAGNOSTIC) $(BOARD_FLAGS) && make -j$(JOBS)"
 
 # Name for the persistent debug container
 DEBUG_CONTAINER := smartphone-robot-debug

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ UART logs can be captured from the host with:
 tools/capture_uart_log.py --flash --timeout 15
 ```
 
+Some phones take longer than the default 2 second MAX77958 diagnostic poll to finish PD negotiation. To poll for longer, rebuild with:
+```bash
+make firmware LOGGER=UART MAX77958_DIAG_POLL_MS=15000
+```
+
 For phone charging plus Android-side motor control, the desired MAX77958 diagnostic state is:
 ```text
 cc=SOURCE_ATTACHED pd_ready=yes robot_usb=device/UFP android_usb=host/DFP vbus_enabled=yes

--- a/README.md
+++ b/README.md
@@ -59,6 +59,35 @@ Flash the firmware to the device:
 make flash
 ```
 
+## Logging and Diagnostics
+Firmware logging defaults to the USB CDC interface:
+```bash
+make firmware LOGGER=USB
+```
+
+To route firmware logs over the debug-probe UART instead, build with:
+```bash
+make firmware LOGGER=UART
+make flash
+```
+
+UART logs can be captured from the host with:
+```bash
+tools/capture_uart_log.py --flash --timeout 15
+```
+
+For isolated MAX77958 prototype testing, build the external I2C1 diagnostic firmware with:
+```bash
+make firmware LOGGER=UART EXTERNAL_MAX77958_TEST=1
+make flash
+tools/capture_uart_log.py --flash --timeout 15
+```
+
+`EXTERNAL_MAX77958_TEST=1` skips normal board bring-up and probes an external MAX77958 on I2C1. Leave it unset, or set it to `0`, for normal firmware:
+```bash
+make firmware LOGGER=UART
+```
+
 ## Debugging the Firmware
 Debugging is a two-step process:
 

--- a/README.md
+++ b/README.md
@@ -76,18 +76,15 @@ UART logs can be captured from the host with:
 tools/capture_uart_log.py --flash --timeout 15
 ```
 
-Some phones take longer than the default 2 second MAX77958 diagnostic poll to finish PD negotiation. To poll for longer, rebuild with:
-```bash
-make firmware LOGGER=UART MAX77958_DIAG_POLL_MS=15000
-```
+Use a longer `--timeout` when you need the log to include normal startup plus manual detach/reattach cycles.
 
 For phone charging plus Android-side motor control, the desired MAX77958 diagnostic state is:
 ```text
-cc=SOURCE_ATTACHED pd_ready=yes robot_usb=device/UFP android_usb=host/DFP vbus_enabled=yes
+pcb_power=SOURCE pcb_data=UFP_DEVICE pd_ready=yes vbus_enabled=yes
 desired phone-control state: yes
 ```
 
-In raw `PD1` logs, `data=0` means the robot/RP2040 is the USB device (`UFP`) and Android is the USB host (`DFP`), which is required for Android to discover the RP2040 USB serial interface. The raw `power_raw` bit is retained for debugging, but the CC source-attach state and GPIO4/GPIO5 VBUS enable are the clearer indicators that the robot is charging the phone.
+In raw `PD1` logs, `data=0` means the robot/RP2040 is the USB device (`UFP`) and Android is the USB host (`DFP`), which is required for Android to discover the RP2040 USB serial interface. The board-relative `pcb_power=SOURCE` state and GPIO4/GPIO5 VBUS enable indicate that the robot is charging the phone.
 
 For isolated MAX77958 prototype testing, build the external I2C1 diagnostic firmware with:
 ```bash

--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ UART logs can be captured from the host with:
 tools/capture_uart_log.py --flash --timeout 15
 ```
 
+For phone charging plus Android-side motor control, the desired MAX77958 diagnostic state is:
+```text
+cc=SOURCE_ATTACHED pd_ready=yes robot_usb=device/UFP android_usb=host/DFP vbus_enabled=yes
+desired phone-control state: yes
+```
+
+In raw `PD1` logs, `data=0` means the robot/RP2040 is the USB device (`UFP`) and Android is the USB host (`DFP`), which is required for Android to discover the RP2040 USB serial interface. The raw `power_raw` bit is retained for debugging, but the CC source-attach state and GPIO4/GPIO5 VBUS enable are the clearer indicators that the robot is charging the phone.
+
 For isolated MAX77958 prototype testing, build the external I2C1 diagnostic firmware with:
 ```bash
 make firmware LOGGER=UART EXTERNAL_MAX77958_TEST=1

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ tools/capture_uart_log.py --flash --timeout 15
 make firmware LOGGER=UART
 ```
 
+Forced VBUS diagnostics are disabled by default. To intentionally force MAX77958 GPIO4/GPIO5 high during bring-up, build with `MAX77958_FORCE_VBUS_DIAGNOSTIC=1`.
+
 ## Debugging the Firmware
 Debugging is a two-step process:
 

--- a/include/max77958.h
+++ b/include/max77958.h
@@ -66,6 +66,7 @@ uint8_t max77958_build_customer_config_value(const max77958_customer_config_t* c
 void max77958_init(uint gpio_interrupt, queue_t* call_queue, queue_t* results_queue);
 void max77958_shutdown(uint gpio_interrupt);
 void max77958_on_interrupt(uint gpio, uint32_t event_mask);
+void max77958_on_start_complete(void);
 void test_max77958_status_block_read_all(void);
 void test_max77958_get_id();
 void test_max77958_bc_ctrl1_read();
@@ -78,7 +79,6 @@ void test_max77958_gpio0_gpio1_adc_read(void);
 void test_max77958_snk_pdo_request(void);
 void test_max77958_get_customer_config();
 void test_max77958_interrupt();
-void max77958_debug_poll_status(uint32_t duration_ms, uint32_t interval_ms);
 void read_reg(uint8_t reg);
 
 #endif

--- a/include/max77958.h
+++ b/include/max77958.h
@@ -78,6 +78,7 @@ void test_max77958_gpio0_gpio1_adc_read(void);
 void test_max77958_snk_pdo_request(void);
 void test_max77958_get_customer_config();
 void test_max77958_interrupt();
+void max77958_debug_poll_status(uint32_t duration_ms, uint32_t interval_ms);
 void read_reg(uint8_t reg);
 
 #endif

--- a/src/max77958.c
+++ b/src/max77958.c
@@ -72,7 +72,7 @@ static int32_t bc_ctrl1_read();
 static int32_t bc_ctrl2_read();
 static int32_t control1_read();
 static int32_t cc_ctrl1_read();
-static int32_t cc_ctrl1_write_src_only(void);
+static int32_t cc_ctrl1_write_snk_only(void);
 static int32_t cc_ctrl4_read(void);
 static int32_t gpio_control_read(void);
 static int32_t gpio0_gpio1_adc_read(void);
@@ -793,13 +793,13 @@ static int32_t cc_ctrl1_read(){
     return 0;
 }
 
-static int32_t cc_ctrl1_write_src_only(void)
+static int32_t cc_ctrl1_write_snk_only(void)
 {
     memset(send_buf, 0, sizeof send_buf);
     send_buf[0] = OPCODE_WRITE;
     send_buf[1] = 0x0C; // CC CTRL1 Config Write
-    send_buf[2] = 0x82; // VCONN auto, Try.SNK off, source-only CC detection
-    rp2040_log("cc_ctrl1_write_src_only: setting CC_CTRL1 to 0x82\n");
+    send_buf[2] = 0x81; // VCONN auto, Try.SNK off, sink-only CC detection
+    rp2040_log("cc_ctrl1_write_snk_only: setting CC_CTRL1 to 0x81\n");
     opcode_write(send_buf);
     return 0;
 }
@@ -819,8 +819,8 @@ void test_max77958_cc_ctrl1_read(){
     if (op_code_return_buf[0] != 0x0B){
 	rp2040_log("test_max77958_cc_ctrl1_read ERROR: OPCODE should be 0x0B");
     }
-    if (op_code_return_buf[1] != 0b10000010){
-        rp2040_log("test_max77958_cc_ctrl1_read ERROR: CC_CTRL1_CONFIG should be 0b10000010 instead it is 0b"
+    if (op_code_return_buf[1] != 0b10000001){
+        rp2040_log("test_max77958_cc_ctrl1_read ERROR: CC_CTRL1_CONFIG should be 0b10000001 instead it is 0b"
            BYTE_TO_BINARY_PATTERN "\n",
            BYTE_TO_BINARY(op_code_return_buf[1]));
     }else{
@@ -1156,12 +1156,10 @@ void max77958_init(uint gpio_interrupt, queue_t* cq, queue_t* rq){
     get_interrupt_vals();
 
     // Add all opcode commands in order to a queue. These will be called sequentially from core1 via the call_queue
-    // Set GPIO5 and GPIO4 to LOW
+    // Keep the phone charging path off by default. Data connectivity is the fail-safe priority.
     opcode_queue_add(gpio_set, gpio_bool_to_int32(false, false));
-    // Set GPIO5 to HIGH and GPIO4 to LOW
-    opcode_queue_add(gpio_set, gpio_bool_to_int32(false, true));
     opcode_queue_add(customer_config_write, 0);
-    opcode_queue_add(cc_ctrl1_write_src_only, 0);
+    opcode_queue_add(cc_ctrl1_write_snk_only, 0);
     opcode_queue_add(cc_ctrl1_read, 0);
     opcode_queue_add(swap_response_write, 0);
 #ifdef MAX77958_FORCE_VBUS_DIAGNOSTIC
@@ -1224,7 +1222,7 @@ static int32_t customer_config_write(){
         .dbg_snk_enable = false, 
         .audio_acc_enable = false,
         .trysnk_enable = false,
-	.typec_mode = TYPEC_MODE_SRC,
+	.typec_mode = TYPEC_MODE_SNK,
         .mem_update_customer = false,  // Update RAM only
         .moisture_enable = false
     };
@@ -1453,7 +1451,7 @@ static void vbus_turn_off(){
     return;
 #endif
     data_role_swap_requested = false;
-    opcode_queue_add(&gpio_set, gpio_bool_to_int32(false, true));
+    opcode_queue_add(&gpio_set, gpio_bool_to_int32(false, false));
     opcode_queue_pop();
 }
 

--- a/src/max77958.c
+++ b/src/max77958.c
@@ -16,9 +16,6 @@ static uint8_t return_buf[33] = {0};
 static uint8_t op_code_return_buf[33] = {0}; // Will read full buffer from registers 0x52 to 0x71
 #define PDMSG_POWER_SUPPLY_VBUS_ENABLE 0x17
 #define PDMSG_POWER_SUPPLY_VBUS_DISABLE 0x18
-#ifdef LOGGER_UART
-#define MAX77958_FORCE_VBUS_DIAGNOSTIC 1
-#endif
 static queue_t* call_queue_ptr;
 static queue_t* return_queue_ptr;
 static bool opcode_cmd_finished = false;

--- a/src/max77958.c
+++ b/src/max77958.c
@@ -16,11 +16,18 @@ static uint8_t return_buf[33] = {0};
 static uint8_t op_code_return_buf[33] = {0}; // Will read full buffer from registers 0x52 to 0x71
 #define PDMSG_POWER_SUPPLY_VBUS_ENABLE 0x17
 #define PDMSG_POWER_SUPPLY_VBUS_DISABLE 0x18
+#define MAX77958_SWAP_REQ_DR_SWAP 0x01
+#define MAX77958_SWAP_REQ_PR_SWAP 0x02
+#define MAX77958_SWAP_RESP_SOURCE_UFP 0x10
+#define CC_STATUS0_STATE_SOURCE 0x02
+#define PD_STATUS1_DATA_ROLE_DFP (1u << 7)
+#define PD_STATUS1_PSRDY (1u << 4)
 static queue_t* call_queue_ptr;
 static queue_t* return_queue_ptr;
 static bool opcode_cmd_finished = false;
 static bool power_swap_enabled = true;
 static bool opcodes_finished = false;
+static bool data_role_swap_requested = false;
 static queue_t opcode_queue;
 static uint8_t _gpio_interrupt;
 static uint8_t interrupt_mask = GPIO_IRQ_EDGE_FALL;
@@ -38,6 +45,9 @@ static void opcode_read();
 static int opcode_write(uint8_t *send_buf);
 static int32_t max77958_test_response();
 static void power_swap_request();
+static int32_t swap_response_write(void);
+static int32_t data_role_swap_request(void);
+static bool queue_data_role_swap_to_ufp_once(void);
 static int32_t set_snk_pdos();
 static int32_t pd_msg_response();
 static int32_t customer_config_write();
@@ -85,6 +95,31 @@ typedef struct {
     uint8_t gpio8;
     bool gpio_valid;
 } max77958_debug_status_t;
+
+static const char *cc_state_name(uint8_t state)
+{
+    switch (state) {
+        case 0: return "NO_CONNECTION";
+        case 1: return "SINK_ATTACHED";
+        case 2: return "SOURCE_ATTACHED";
+        case 3: return "AUDIO_ACCESSORY";
+        case 4: return "DEBUG_SOURCE";
+        case 5: return "ERROR";
+        case 6: return "DISABLED";
+        case 7: return "DEBUG_SINK";
+        default: return "UNKNOWN";
+    }
+}
+
+static const char *data_role_name(uint8_t data_role)
+{
+    return data_role ? "DFP_HOST" : "UFP_DEVICE";
+}
+
+static const char *ready_name(uint8_t psrdy)
+{
+    return psrdy ? "READY" : "NOT_READY";
+}
 
 
 
@@ -249,6 +284,9 @@ static int32_t parse_interrupt_vals(){
     if (*PD_INT & PSRDYI_mask){
 	rp2040_log("Power source ready\n");
 	//on_power_source_ready();
+        if (queue_data_role_swap_to_ufp_once()) {
+            opcode_queue_pop();
+        }
 	return_val |= 1 << 1;
     }
     if (*PD_INT & PDMsgI){
@@ -406,15 +444,17 @@ static void max77958_debug_log_status(uint32_t elapsed_ms, const max77958_debug_
 
     rp2040_log("MAX77958_DIAG t=%" PRIu32 "ms USBC1=0x%02x VbADC=%u SYS=0x%02x BC=0x%02x\n",
                 elapsed_ms, status->usbc_status1, vbadc, status->usbc_status2, status->bc_status);
-    rp2040_log("MAX77958_DIAG t=%" PRIu32 "ms CC0=0x%02x pin=%u current=%u state=%u\n",
-                elapsed_ms, status->cc_status0, cc_pin, cc_current, cc_state);
+    rp2040_log("MAX77958_DIAG t=%" PRIu32 "ms CC0=0x%02x pin=%u current=%u state=%u(%s)\n",
+                elapsed_ms, status->cc_status0, cc_pin, cc_current, cc_state,
+                cc_state_name(cc_state));
     rp2040_log("MAX77958_DIAG t=%" PRIu32 "ms CC1=0x%02x wtr=%u detabrt=%u vsafeov=%u\n",
                 elapsed_ms, status->cc_status1,
                 (status->cc_status1 >> 1) & 0x01,
                 (status->cc_status1 >> 2) & 0x01,
                 (status->cc_status1 >> 3) & 0x01);
-    rp2040_log("MAX77958_DIAG t=%" PRIu32 "ms PD0=0x%02x PD1=0x%02x power=%u data=%u psrdy=%u\n",
-                elapsed_ms, status->pd_status0, status->pd_status1, power_role, data_role, psrdy);
+    rp2040_log("MAX77958_DIAG t=%" PRIu32 "ms PD0=0x%02x PD1=0x%02x power_raw=%u data=%u(%s) psrdy=%u(%s)\n",
+                elapsed_ms, status->pd_status0, status->pd_status1, power_role,
+                data_role, data_role_name(data_role), psrdy, ready_name(psrdy));
     rp2040_log("MAX77958_DIAG t=%" PRIu32 "ms GPIO53=0x%02x valid=%u g4=%u/%u g5=%u/%u\n",
                 elapsed_ms, status->gpio4_7, status->gpio_valid ? 1 : 0,
                 g4_dir, g4_out, g5_dir, g5_out);
@@ -1035,6 +1075,7 @@ void max77958_init(uint gpio_interrupt, queue_t* cq, queue_t* rq){
     opcode_queue_add(customer_config_write, 0);
     opcode_queue_add(cc_ctrl1_write_src_only, 0);
     opcode_queue_add(cc_ctrl1_read, 0);
+    opcode_queue_add(swap_response_write, 0);
 #ifdef MAX77958_FORCE_VBUS_DIAGNOSTIC
     opcode_queue_add(force_vbus_on_for_diagnostic, 0);
 #endif
@@ -1184,9 +1225,62 @@ static int32_t gpio_set(int32_t gpio_val){
 static void power_swap_request(){
     memset(send_buf, 0, sizeof send_buf);
     send_buf[0] = OPCODE_WRITE;
-    send_buf[1] = 0x37; // Send Swap Request 
-    send_buf[2] = 0x02; // PR SWAP
+    send_buf[1] = OPCODE_SWAP_REQ;
+    send_buf[2] = MAX77958_SWAP_REQ_PR_SWAP;
     opcode_write(send_buf);
+}
+
+static int32_t swap_response_write(void)
+{
+    memset(send_buf, 0, sizeof send_buf);
+    send_buf[0] = OPCODE_WRITE;
+    send_buf[1] = OPCODE_SWAP_RESP;
+    send_buf[2] = MAX77958_SWAP_RESP_SOURCE_UFP;
+    rp2040_log("MAX77958_DIAG: setting swap response power=Source data=UFP config=0x%02x\n",
+                send_buf[2]);
+    opcode_write(send_buf);
+    return 0;
+}
+
+static int32_t data_role_swap_request(void)
+{
+    memset(send_buf, 0, sizeof send_buf);
+    send_buf[0] = OPCODE_WRITE;
+    send_buf[1] = OPCODE_SWAP_REQ;
+    send_buf[2] = MAX77958_SWAP_REQ_DR_SWAP;
+    rp2040_log("MAX77958_DIAG: requesting DR_SWAP to make robot UFP/device\n");
+    opcode_write(send_buf);
+    return 0;
+}
+
+static bool queue_data_role_swap_to_ufp_once(void)
+{
+    if (data_role_swap_requested) {
+        return false;
+    }
+
+    uint8_t cc_status0 = max77958_read_register(REG_CC_STATUS0);
+    uint8_t pd_status1 = max77958_read_register(REG_PD_STATUS1);
+    bool source_attached = (cc_status0 & 0x07) == CC_STATUS0_STATE_SOURCE;
+    bool dfp = (pd_status1 & PD_STATUS1_DATA_ROLE_DFP) != 0;
+    bool psrdy = (pd_status1 & PD_STATUS1_PSRDY) != 0;
+
+    rp2040_log("MAX77958_DIAG: DR_SWAP check CC0=0x%02x source=%u PD1=0x%02x data=%u psrdy=%u\n",
+                cc_status0, source_attached ? 1 : 0, pd_status1, dfp ? 1 : 0, psrdy ? 1 : 0);
+
+    if (!source_attached || !psrdy) {
+        return false;
+    }
+
+    if (!dfp) {
+        rp2040_log("MAX77958_DIAG: data role already UFP/device\n");
+        data_role_swap_requested = true;
+        return false;
+    }
+
+    data_role_swap_requested = true;
+    opcode_queue_add(data_role_swap_request, 0);
+    return true;
 }
 
 static int32_t set_src_pdos(){
@@ -1270,6 +1364,7 @@ static void vbus_turn_off(){
     rp2040_log("MAX77958_DIAG: forced VBUS mode ignoring vbus_turn_off\n");
     return;
 #endif
+    data_role_swap_requested = false;
     opcode_queue_add(&gpio_set, gpio_bool_to_int32(false, true));
     opcode_queue_pop();
 }
@@ -1284,6 +1379,7 @@ static int32_t force_vbus_on_for_diagnostic(void)
 
 static void vbus_turn_on(){
     opcode_queue_add(&gpio_set, gpio_bool_to_int32(true, true));
+    queue_data_role_swap_to_ufp_once();
     opcode_queue_pop();
 }
 
@@ -1296,6 +1392,12 @@ static int32_t pd_msg_response(){
     i2c_read_error_handling(i2c0, MAX77958_SLAVE_P1, return_buf, 1, false);
     rp2040_log("PD_STATUS0: 0x%02x\n", return_buf[0]);
     switch (return_buf[0]){
+        case PDMSG_DR_SWAP_REQ_RECEIVED:
+	    rp2040_log("PD Message: DR_SWAP_REQ_RECEIVED\n");
+	    break;
+        case PDMSG_REJECT_RECEIVED:
+	    rp2040_log("PD Message: REJECT_RECEIVED\n");
+	    break;
         case PDMSG_PRSWAP_SRCTOSWAP:
 	    rp2040_log("PD Message: PRSWAP_SRCTOSWAP\n");
 	    break;

--- a/src/max77958.c
+++ b/src/max77958.c
@@ -14,6 +14,11 @@
 static uint8_t send_buf[33] = {0};
 static uint8_t return_buf[33] = {0}; 
 static uint8_t op_code_return_buf[33] = {0}; // Will read full buffer from registers 0x52 to 0x71
+#define PDMSG_POWER_SUPPLY_VBUS_ENABLE 0x17
+#define PDMSG_POWER_SUPPLY_VBUS_DISABLE 0x18
+#ifdef LOGGER_UART
+#define MAX77958_FORCE_VBUS_DIAGNOSTIC 1
+#endif
 static queue_t* call_queue_ptr;
 static queue_t* return_queue_ptr;
 static bool opcode_cmd_finished = false;
@@ -31,6 +36,7 @@ static void on_interrupt();
 static void get_interrupt_vals();
 static void get_interrupt_masks();
 static void set_interrupt_masks();
+static uint8_t max77958_read_register(uint8_t reg);
 static void opcode_read();
 static int opcode_write(uint8_t *send_buf);
 static int32_t max77958_test_response();
@@ -42,6 +48,9 @@ static bool opcode_queue_pop();
 static void opcode_queue_add(int32_t (*opcode_func)(), int32_t opcode_data);
 static int32_t gpio_bool_to_int32(bool _GPIO4, bool _GPIO5);
 static int32_t gpio_set(int32_t gpio_val);
+#ifdef MAX77958_FORCE_VBUS_DIAGNOSTIC
+static int32_t force_vbus_on_for_diagnostic(void);
+#endif
 static int32_t set_src_pdos();
 static void on_ccstat_change();
 static void on_chgtype_change();
@@ -54,6 +63,7 @@ static int32_t bc_ctrl1_read();
 static int32_t bc_ctrl2_read();
 static int32_t control1_read();
 static int32_t cc_ctrl1_read();
+static int32_t cc_ctrl1_write_src_only(void);
 static int32_t cc_ctrl4_read(void);
 static int32_t gpio_control_read(void);
 static int32_t gpio0_gpio1_adc_read(void);
@@ -64,6 +74,20 @@ typedef struct {
     uint8_t reg;
     uint8_t expected;
 } max77958_status_reg_t;
+
+typedef struct {
+    uint8_t usbc_status1;
+    uint8_t usbc_status2;
+    uint8_t bc_status;
+    uint8_t cc_status0;
+    uint8_t cc_status1;
+    uint8_t pd_status0;
+    uint8_t pd_status1;
+    uint8_t gpio0_3;
+    uint8_t gpio4_7;
+    uint8_t gpio8;
+    bool gpio_valid;
+} max77958_debug_status_t;
 
 
 
@@ -151,7 +175,7 @@ static void on_ccstat_change(void) {
             break;
         case 0b010:
             rp2040_log("CCStat: ccstat changed to SOURCE\n");
-            //vbus_turn_on();
+            vbus_turn_on();
             break;
         default:
             rp2040_log("CCStat: ccstat changed to %d\n", CCStat);
@@ -319,6 +343,115 @@ void read_reg(uint8_t reg){
     rp2040_log("read_reg: 0x%02x: 0x%02x\n", reg, return_buf[0]);
 }
 
+static bool max77958_debug_read_gpio_control(max77958_debug_status_t *status)
+{
+    memset(op_code_return_buf, 0, sizeof op_code_return_buf);
+    opcodes_finished = false;
+
+    opcode_queue_add(gpio_control_read, 0);
+    if (!opcode_queue_pop()) {
+        rp2040_log("MAX77958_DIAG: GPIO read queue was empty\n");
+        return false;
+    }
+
+    uint32_t waited_ms = 0;
+    while (!opcodes_finished && waited_ms < 500) {
+        sleep_ms(10);
+        waited_ms += 10;
+    }
+
+    if (!opcodes_finished) {
+        rp2040_log("MAX77958_DIAG: GPIO read timed out\n");
+        return false;
+    }
+
+    if (op_code_return_buf[0] != OPCODE_READ_GPIO) {
+        rp2040_log("MAX77958_DIAG: GPIO read unexpected opcode 0x%02x\n", op_code_return_buf[0]);
+        return false;
+    }
+
+    status->gpio0_3 = op_code_return_buf[1];
+    status->gpio4_7 = op_code_return_buf[2];
+    status->gpio8 = op_code_return_buf[3];
+    status->gpio_valid = true;
+    return true;
+}
+
+static max77958_debug_status_t max77958_debug_read_status(void)
+{
+    max77958_debug_status_t status = {0};
+
+    status.usbc_status1 = max77958_read_register(0x08);
+    status.usbc_status2 = max77958_read_register(0x09);
+    status.bc_status = max77958_read_register(0x0A);
+    status.cc_status0 = max77958_read_register(0x0C);
+    status.cc_status1 = max77958_read_register(0x0D);
+    status.pd_status0 = max77958_read_register(0x0E);
+    status.pd_status1 = max77958_read_register(0x0F);
+    max77958_debug_read_gpio_control(&status);
+
+    return status;
+}
+
+static void max77958_debug_log_status(uint32_t elapsed_ms, const max77958_debug_status_t *status)
+{
+    uint8_t vbadc = (status->usbc_status1 >> 3) & 0x1F;
+    uint8_t cc_pin = (status->cc_status0 >> 6) & 0x03;
+    uint8_t cc_current = (status->cc_status0 >> 4) & 0x03;
+    uint8_t cc_state = status->cc_status0 & 0x07;
+    uint8_t power_role = (status->pd_status1 >> 6) & 0x01;
+    uint8_t data_role = (status->pd_status1 >> 7) & 0x01;
+    uint8_t psrdy = (status->pd_status1 >> 4) & 0x01;
+    uint8_t g4_dir = status->gpio4_7 & 0x01;
+    uint8_t g4_out = (status->gpio4_7 >> 1) & 0x01;
+    uint8_t g5_dir = (status->gpio4_7 >> 2) & 0x01;
+    uint8_t g5_out = (status->gpio4_7 >> 3) & 0x01;
+
+    rp2040_log("MAX77958_DIAG t=%" PRIu32 "ms USBC1=0x%02x VbADC=%u SYS=0x%02x BC=0x%02x\n",
+                elapsed_ms, status->usbc_status1, vbadc, status->usbc_status2, status->bc_status);
+    rp2040_log("MAX77958_DIAG t=%" PRIu32 "ms CC0=0x%02x pin=%u current=%u state=%u\n",
+                elapsed_ms, status->cc_status0, cc_pin, cc_current, cc_state);
+    rp2040_log("MAX77958_DIAG t=%" PRIu32 "ms CC1=0x%02x wtr=%u detabrt=%u vsafeov=%u\n",
+                elapsed_ms, status->cc_status1,
+                (status->cc_status1 >> 1) & 0x01,
+                (status->cc_status1 >> 2) & 0x01,
+                (status->cc_status1 >> 3) & 0x01);
+    rp2040_log("MAX77958_DIAG t=%" PRIu32 "ms PD0=0x%02x PD1=0x%02x power=%u data=%u psrdy=%u\n",
+                elapsed_ms, status->pd_status0, status->pd_status1, power_role, data_role, psrdy);
+    rp2040_log("MAX77958_DIAG t=%" PRIu32 "ms GPIO53=0x%02x valid=%u g4=%u/%u g5=%u/%u\n",
+                elapsed_ms, status->gpio4_7, status->gpio_valid ? 1 : 0,
+                g4_dir, g4_out, g5_dir, g5_out);
+}
+
+void max77958_debug_poll_status(uint32_t duration_ms, uint32_t interval_ms)
+{
+    if (interval_ms == 0) {
+        interval_ms = 1000;
+    }
+
+    rp2040_log("MAX77958_DIAG: begin status poll for %" PRIu32 "ms every %" PRIu32 "ms\n",
+                duration_ms, interval_ms);
+
+    uint32_t elapsed_ms = 0;
+    while (elapsed_ms <= duration_ms) {
+        max77958_debug_status_t status = max77958_debug_read_status();
+        max77958_debug_log_status(elapsed_ms, &status);
+
+        if (elapsed_ms == duration_ms) {
+            break;
+        }
+
+        uint32_t sleep_for_ms = interval_ms;
+        if (elapsed_ms + sleep_for_ms > duration_ms) {
+            sleep_for_ms = duration_ms - elapsed_ms;
+        }
+        sleep_ms(sleep_for_ms);
+        elapsed_ms += sleep_for_ms;
+    }
+
+    rp2040_log("MAX77958_DIAG: end status poll\n");
+}
+
 static int opcode_write(uint8_t *buf){
     // buf should always be 32 bytes long since the register values from 0x22 to 0x41 are never overwritten,
     // so you may send wrong data if you don't directly specify them for ALL registers. Note the defaults are NOT always 0x00,
@@ -345,6 +478,9 @@ static void opcode_read(){
     i2c_write_error_handling(i2c0, MAX77958_SLAVE_P1, send_buf, 1, true);
     i2c_read_error_handling(i2c0, MAX77958_SLAVE_P1, op_code_return_buf, 33, false);
     rp2040_log("opcode_read: 0x%02x 0x%02x 0x%02x 0x%02x\n", op_code_return_buf[0], op_code_return_buf[1], op_code_return_buf[2], op_code_return_buf[3]);
+    if (op_code_return_buf[0] == 0x0B) {
+        rp2040_log("CC_CTRL1 readback = 0x%02x\n", op_code_return_buf[1]);
+    }
     // Set breakpoint before clearing the registers via the following command. 
     // I'm commenting this out since I won't use the output in the code, but you can copy/paste this into gdb if you want to
     // inspect the results before clearing them
@@ -532,6 +668,17 @@ static int32_t cc_ctrl1_read(){
     return 0;
 }
 
+static int32_t cc_ctrl1_write_src_only(void)
+{
+    memset(send_buf, 0, sizeof send_buf);
+    send_buf[0] = OPCODE_WRITE;
+    send_buf[1] = 0x0C; // CC CTRL1 Config Write
+    send_buf[2] = 0x82; // VCONN auto, Try.SNK off, source-only CC detection
+    rp2040_log("cc_ctrl1_write_src_only: setting CC_CTRL1 to 0x82\n");
+    opcode_write(send_buf);
+    return 0;
+}
+
 void test_max77958_cc_ctrl1_read(){
     rp2040_log("test_max77958_cc_ctrl1_read started...\n");
     opcode_queue_add(cc_ctrl1_read, 0);
@@ -547,8 +694,8 @@ void test_max77958_cc_ctrl1_read(){
     if (op_code_return_buf[0] != 0x0B){
 	rp2040_log("test_max77958_cc_ctrl1_read ERROR: OPCODE should be 0x0B");
     }
-    if (op_code_return_buf[1] != 0b10000001){
-        rp2040_log("test_max77958_cc_ctrl1_read ERROR: CC_CTRL1_CONFIG should be 0b10000001 instead it is 0b"
+    if (op_code_return_buf[1] != 0b10000010){
+        rp2040_log("test_max77958_cc_ctrl1_read ERROR: CC_CTRL1_CONFIG should be 0b10000010 instead it is 0b"
            BYTE_TO_BINARY_PATTERN "\n",
            BYTE_TO_BINARY(op_code_return_buf[1]));
     }else{
@@ -889,10 +1036,27 @@ void max77958_init(uint gpio_interrupt, queue_t* cq, queue_t* rq){
     // Set GPIO5 to HIGH and GPIO4 to LOW
     opcode_queue_add(gpio_set, gpio_bool_to_int32(false, true));
     opcode_queue_add(customer_config_write, 0);
+    opcode_queue_add(cc_ctrl1_write_src_only, 0);
+    opcode_queue_add(cc_ctrl1_read, 0);
+#ifdef MAX77958_FORCE_VBUS_DIAGNOSTIC
+    opcode_queue_add(force_vbus_on_for_diagnostic, 0);
+#endif
     //opcode_queue_add(set_snk_pdos, 0);
     //opcode_queue_add(set_src_pdos, 0);
 
     opcode_queue_pop();
+#ifdef MAX77958_FORCE_VBUS_DIAGNOSTIC
+    uint32_t waited_ms = 0;
+    while (!opcodes_finished && waited_ms < 3000) {
+        sleep_ms(10);
+        waited_ms += 10;
+    }
+    if (opcodes_finished) {
+        rp2040_log("MAX77958_DIAG: init opcode queue finished after %" PRIu32 "ms\n", waited_ms);
+    } else {
+        rp2040_log("MAX77958_DIAG: init opcode queue timed out after %" PRIu32 "ms\n", waited_ms);
+    }
+#endif
     rp2040_log("max77958 init finished\n");
     on_ccstat_change();
 
@@ -934,7 +1098,7 @@ static int32_t customer_config_write(){
         .dbg_snk_enable = false, 
         .audio_acc_enable = false,
         .trysnk_enable = false,
-	.typec_mode = TYPEC_MODE_DRP,
+	.typec_mode = TYPEC_MODE_SRC,
         .mem_update_customer = false,  // Update RAM only
         .moisture_enable = false
     };
@@ -952,8 +1116,12 @@ static int32_t customer_config_write(){
     send_buf[7] = 0x00; // RSVD
     send_buf[8] = 0x64; // default SRC_PDO_V
     send_buf[9] = 0x00; // default SRC_PDO_V of 5.0V (0x64= 100, and 50mA*100).
-    send_buf[10] = 0x32; // SRC_PDO_MaxI
-    send_buf[11] = 0x00; // SRC_PDO_MaxI = 1.0A (0x64=100, and 100*10mA)
+    send_buf[10] = 0x96; // SRC_PDO_MaxI
+    send_buf[11] = 0x00; // SRC_PDO_MaxI = 1.5A (0x96=150, and 150*10mA)
+    send_buf[21] = 0x69; // SID1 default
+    send_buf[22] = 0x69; // SID2 default
+    send_buf[23] = 0x35; // SID3 default
+    send_buf[24] = 0x28; // SID4 default
     opcode_write(send_buf);
     return 0;
 }
@@ -1101,9 +1269,21 @@ static int32_t set_snk_pdos(){
 }
 
 static void vbus_turn_off(){
+#ifdef MAX77958_FORCE_VBUS_DIAGNOSTIC
+    rp2040_log("MAX77958_DIAG: forced VBUS mode ignoring vbus_turn_off\n");
+    return;
+#endif
     opcode_queue_add(&gpio_set, gpio_bool_to_int32(false, true));
     opcode_queue_pop();
 }
+
+#ifdef MAX77958_FORCE_VBUS_DIAGNOSTIC
+static int32_t force_vbus_on_for_diagnostic(void)
+{
+    rp2040_log("MAX77958_DIAG: forcing GPIO4/GPIO5 high for VBUS diagnostic\n");
+    return gpio_set(gpio_bool_to_int32(true, true));
+}
+#endif
 
 static void vbus_turn_on(){
     opcode_queue_add(&gpio_set, gpio_bool_to_int32(true, true));
@@ -1132,6 +1312,14 @@ static int32_t pd_msg_response(){
 	case PDMSG_PRSWAP_SWAPTOSRC:
 	    rp2040_log("PD Message: PRSWAP_SWAPTOSRC\n");
 	    vbus_turn_on();
+	    break;
+	case PDMSG_POWER_SUPPLY_VBUS_ENABLE:
+	    rp2040_log("PD Message: PowerSupply VbusEnable\n");
+	    vbus_turn_on();
+	    break;
+	case PDMSG_POWER_SUPPLY_VBUS_DISABLE:
+	    rp2040_log("PD Message: PowerSupply VbusDisable\n");
+	    vbus_turn_off();
 	    break;
 	case PDMSG_VDM_NAK_RECEIVED:
 	    rp2040_log("PD Message: VDM_NAK Received\n");

--- a/src/max77958.c
+++ b/src/max77958.c
@@ -19,17 +19,41 @@ static uint8_t op_code_return_buf[33] = {0}; // Will read full buffer from regis
 #define MAX77958_SWAP_REQ_DR_SWAP 0x01
 #define MAX77958_SWAP_REQ_PR_SWAP 0x02
 #define MAX77958_SWAP_RESP_SOURCE_UFP 0x10
+#define CC_STATUS0_STATE_SINK 0x01
 #define CC_STATUS0_STATE_SOURCE 0x02
 #define PD_STATUS1_DATA_ROLE_DFP (1u << 7)
 #define PD_STATUS1_PSRDY (1u << 4)
-#define MAX77958_DIAG_DR_SWAP_RETRY_INTERVAL_MS 1000
-#define MAX77958_DIAG_DR_SWAP_MAX_RETRIES 10
+#define MAX77958_PR_SWAP_MAX_RETRIES 5
+#define MAX77958_STARTUP_SETTLE_MS 300
+#define MAX77958_ROLE_RECHECK_DELAY_MS 250
+#define MAX77958_SOURCE_DFP_NOT_READY_MAX_RECHECKS 8
+#define MAX77958_POST_PRSWAP_VBUS_MAX_RECHECKS 8
+#define MAX77958_RECHECK_SOURCE_DFP_NOT_READY 1
+#define MAX77958_RECHECK_POST_PRSWAP_VBUS 2
+#define MAX77958_OPCODE_WAIT_POLL_MS 10
+#define MAX77958_OPCODE_WAIT_DRAIN_MS 100
+#define MAX77958_OPCODE_WAIT_TIMEOUT_MS 1500
+#define MAX77958_UIC_INT_AP_CMD_RES (1u << 7)
+#define MAX77958_UIC_INT_CHG_TYPE (1u << 1)
+#define MAX77958_PD_INT_PS_RDY (1u << 6)
+#define MAX77958_PD_INT_MSG (1u << 7)
+#define MAX77958_CC_INT_CC_STAT (1u << 0)
+#define MAX77958_CC_INT_CCV_CN_STAT (1u << 1)
+#define MAX77958_CC_INT_CCI_STAT (1u << 2)
+#define MAX77958_CC_INT_CC_PIN_STAT (1u << 3)
 static queue_t* call_queue_ptr;
 static queue_t* return_queue_ptr;
 static bool opcode_cmd_finished = false;
 static bool power_swap_enabled = true;
 static bool opcodes_finished = false;
 static bool data_role_swap_requested = false;
+static bool init_config_pending = false;
+static uint8_t power_role_swap_request_count = 0;
+static bool vbus_enable_requested = false;
+static bool source_dfp_not_ready_recheck_pending = false;
+static bool post_prswap_vbus_recheck_pending = false;
+static uint8_t source_dfp_not_ready_recheck_count = 0;
+static uint8_t post_prswap_vbus_recheck_count = 0;
 static queue_t opcode_queue;
 static uint8_t _gpio_interrupt;
 static uint8_t interrupt_mask = GPIO_IRQ_EDGE_FALL;
@@ -38,17 +62,27 @@ static bool test_max77958_started = false;
 static bool test_max77958_completed = false;
 
 static int32_t parse_interrupt_vals();
+static int32_t handle_interrupt_vals(uint8_t uic_int, uint8_t cc_int, uint8_t pd_int);
 static void on_interrupt();
 static void get_interrupt_vals();
 static void get_interrupt_masks();
 static void set_interrupt_masks();
 static uint8_t max77958_read_register(uint8_t reg);
 static void opcode_read();
+static bool wait_for_opcode_response(const char *context, uint32_t timeout_ms);
+static bool service_pending_interrupt_snapshot(const char *context, bool log_snapshot);
 static int opcode_write(uint8_t *send_buf);
 static int32_t max77958_test_response();
-static void power_swap_request();
+static int32_t power_swap_request(void);
 static int32_t swap_response_write(void);
 static int32_t data_role_swap_request(void);
+static bool evaluate_current_role_state(const char *reason);
+static bool queue_power_role_swap_to_source_if_ready(const char *reason);
+static bool queue_data_role_swap_to_ufp_if_ready(const char *reason);
+static bool queue_vbus_on_after_pr_swap_if_source_attached(void);
+static int32_t delayed_role_recheck(int32_t reason);
+static int64_t delayed_role_recheck_alarm(alarm_id_t id, void *user_data);
+static void schedule_delayed_role_recheck(int32_t reason);
 static bool queue_data_role_swap_to_ufp_once(void);
 static int32_t set_snk_pdos();
 static int32_t pd_msg_response();
@@ -84,22 +118,26 @@ typedef struct {
     uint8_t expected;
 } max77958_status_reg_t;
 
-typedef struct {
-    uint8_t usbc_status1;
-    uint8_t usbc_status2;
-    uint8_t bc_status;
-    uint8_t cc_status0;
-    uint8_t cc_status1;
-    uint8_t pd_status0;
-    uint8_t pd_status1;
-    uint8_t gpio0_3;
-    uint8_t gpio4_7;
-    uint8_t gpio8;
-    bool gpio_valid;
-} max77958_debug_status_t;
+typedef enum {
+    MAX77958_PCB_POWER_UNKNOWN,
+    MAX77958_PCB_POWER_SINK,
+    MAX77958_PCB_POWER_SOURCE,
+} max77958_pcb_power_role_t;
 
-static void max77958_debug_maybe_retry_data_role_swap(uint32_t elapsed_ms,
-                                                      const max77958_debug_status_t *status);
+typedef enum {
+    MAX77958_PCB_DATA_UFP_DEVICE,
+    MAX77958_PCB_DATA_DFP_HOST,
+} max77958_pcb_data_role_t;
+
+typedef struct {
+    uint8_t cc_status0;
+    uint8_t pd_status1;
+    uint8_t cc_state;
+    max77958_pcb_power_role_t pcb_power;
+    max77958_pcb_data_role_t pcb_data;
+    bool pd_ready;
+    bool attached;
+} max77958_role_state_t;
 
 static const char *cc_state_name(uint8_t state)
 {
@@ -121,9 +159,68 @@ static const char *data_role_name(uint8_t data_role)
     return data_role ? "DFP_HOST" : "UFP_DEVICE";
 }
 
+static const char *pcb_power_role_name(max77958_pcb_power_role_t role)
+{
+    switch (role) {
+        case MAX77958_PCB_POWER_SINK: return "SINK";
+        case MAX77958_PCB_POWER_SOURCE: return "SOURCE";
+        case MAX77958_PCB_POWER_UNKNOWN:
+        default: return "UNKNOWN";
+    }
+}
+
+static const char *pcb_data_role_name(max77958_pcb_data_role_t role)
+{
+    switch (role) {
+        case MAX77958_PCB_DATA_DFP_HOST: return "DFP_HOST";
+        case MAX77958_PCB_DATA_UFP_DEVICE:
+        default: return "UFP_DEVICE";
+    }
+}
+
 static const char *ready_name(uint8_t psrdy)
 {
     return psrdy ? "READY" : "NOT_READY";
+}
+
+static max77958_role_state_t max77958_read_role_state(void)
+{
+    max77958_role_state_t state = {0};
+
+    state.cc_status0 = max77958_read_register(REG_CC_STATUS0);
+    state.pd_status1 = max77958_read_register(REG_PD_STATUS1);
+    state.cc_state = state.cc_status0 & 0x07;
+    state.pd_ready = (state.pd_status1 & PD_STATUS1_PSRDY) != 0;
+    state.pcb_data = (state.pd_status1 & PD_STATUS1_DATA_ROLE_DFP) != 0
+        ? MAX77958_PCB_DATA_DFP_HOST
+        : MAX77958_PCB_DATA_UFP_DEVICE;
+
+    switch (state.cc_state) {
+        case CC_STATUS0_STATE_SINK:
+            state.pcb_power = MAX77958_PCB_POWER_SINK;
+            state.attached = true;
+            break;
+        case CC_STATUS0_STATE_SOURCE:
+            state.pcb_power = MAX77958_PCB_POWER_SOURCE;
+            state.attached = true;
+            break;
+        default:
+            state.pcb_power = MAX77958_PCB_POWER_UNKNOWN;
+            state.attached = false;
+            break;
+    }
+
+    return state;
+}
+
+static void log_role_state(const char *prefix, const char *reason, const max77958_role_state_t *state)
+{
+    rp2040_log("MAX77958_DIAG: %s reason=%s CC0=0x%02x state=%u(%s) PD1=0x%02x pcb_power=%s pcb_data=%s pd_ready=%u(%s)\n",
+                prefix, reason, state->cc_status0, state->cc_state,
+                cc_state_name(state->cc_state), state->pd_status1,
+                pcb_power_role_name(state->pcb_power),
+                pcb_data_role_name(state->pcb_data),
+                state->pd_ready ? 1 : 0, ready_name(state->pd_ready ? 1 : 0));
 }
 
 
@@ -150,6 +247,13 @@ static int on_opcode_cmd_response(){
     // opcode_queue_pop will return false if the opcode queue is empty
     if (!opcode_queue_pop()){
         opcodes_finished = true;
+        if (init_config_pending) {
+            init_config_pending = false;
+            sleep_ms(MAX77958_STARTUP_SETTLE_MS);
+            if (evaluate_current_role_state("init complete")) {
+                opcode_queue_pop();
+            }
+        }
     }
     return 0;
 }
@@ -204,15 +308,26 @@ static void on_ccstat_change(void) {
     switch (CCStat){
         case 0b000:
             rp2040_log("CCStat: ccstat changed to no connection\n");
-            vbus_turn_off();
+            if (init_config_pending) {
+                rp2040_log("MAX77958_DIAG: deferring detach action while init config is pending\n");
+            } else {
+                power_role_swap_request_count = 0;
+                vbus_turn_off();
+            }
             break;
         case 0b001:
             rp2040_log("CCStat: ccstat changed to SINK\n");
-            vbus_turn_off();
+            if (init_config_pending) {
+                rp2040_log("MAX77958_DIAG: deferring sink action while init config is pending\n");
+            } else {
+                vbus_turn_off();
+            }
             break;
         case 0b010:
             rp2040_log("CCStat: ccstat changed to SOURCE\n");
-            vbus_turn_on();
+            if (init_config_pending) {
+                rp2040_log("MAX77958_DIAG: deferring VBUS enable for init-time SOURCE transient\n");
+            }
             break;
         default:
             rp2040_log("CCStat: ccstat changed to %d\n", CCStat);
@@ -267,54 +382,56 @@ static void opcode_queue_add(int32_t (opcode_func)(), int32_t opcode_data){
 } 
 
 static int32_t parse_interrupt_vals(){
-    uint16_t return_val = 0;
     get_interrupt_vals();
     // don't really need these, but makes it easier to understand what each entry to the return_buf represents
-    uint8_t* UIC_INT = &return_buf[0]; 
-    uint8_t* CC_INT = &return_buf[1]; 
-    uint8_t* PD_INT = &return_buf[2]; 
-    // Check if the APCmdResI interrupt is on (AP command response pending)
-    uint8_t APCmdResI_mask = 1 << 7;
-    uint8_t PSRDYI_mask = 1 << 6;
-    uint8_t PDMsgI = 1 << 7;
-    uint8_t CCStat = 1 << 0;
-    uint8_t ChgType = 1 << 1;
-    uint8_t CCVcnStatI = 1 << 1;
-    uint8_t CCIStatI = 1 << 2;
-    uint8_t CCPinStatI = 1 << 3;
-    if (*UIC_INT & APCmdResI_mask){
+    uint8_t UIC_INT = return_buf[0];
+    uint8_t CC_INT = return_buf[1];
+    uint8_t PD_INT = return_buf[2];
+
+    return handle_interrupt_vals(UIC_INT, CC_INT, PD_INT);
+}
+
+static int32_t handle_interrupt_vals(uint8_t UIC_INT, uint8_t CC_INT, uint8_t PD_INT)
+{
+    uint16_t return_val = 0;
+
+    if (UIC_INT & MAX77958_UIC_INT_AP_CMD_RES){
 	on_opcode_cmd_response();
 	return_val |= 1 << 0;
     }
-    if (*PD_INT & PSRDYI_mask){
+    if (PD_INT & MAX77958_PD_INT_PS_RDY){
 	rp2040_log("Power source ready\n");
-	//on_power_source_ready();
-        if (queue_data_role_swap_to_ufp_once()) {
+        if (init_config_pending) {
+            rp2040_log("MAX77958_DIAG: ignoring PSRDY action while init config is pending\n");
+        } else if (evaluate_current_role_state("PSRDY")) {
             opcode_queue_pop();
-        }
+	}
 	return_val |= 1 << 1;
     }
-    if (*PD_INT & PDMsgI){
+    if (PD_INT & MAX77958_PD_INT_MSG){
 	on_pd_msg_received();
 	return_val |= 1 << 2;
     }
-    if (*UIC_INT & ChgType){
+    if (UIC_INT & MAX77958_UIC_INT_CHG_TYPE){
 	on_chgtype_change();
 	return_val |= 1 << 3;
     }
-    if (*CC_INT & CCStat){
+    if (CC_INT & MAX77958_CC_INT_CC_STAT){
 	on_ccstat_change();
+        if (!init_config_pending && evaluate_current_role_state("CCStat")) {
+            opcode_queue_pop();
+	}
 	return_val |= 1 << 4;
     }
-    if (*CC_INT & CCVcnStatI){
+    if (CC_INT & MAX77958_CC_INT_CCV_CN_STAT){
 	on_ccvcnstat_change();
 	return_val |= 1 << 5;
     }
-    if (*CC_INT & CCIStatI){
+    if (CC_INT & MAX77958_CC_INT_CCI_STAT){
 	on_ccistat_change();
 	return_val |= 1 << 6;
     }
-    if (*CC_INT & CCPinStatI){
+    if (CC_INT & MAX77958_CC_INT_CC_PIN_STAT){
 	on_ccpinstat_change();
 	return_val |= 1 << 7;
     }
@@ -322,7 +439,7 @@ static int32_t parse_interrupt_vals(){
 	test_max77958_interrupt_bool = true;
     }
     return return_val;
-    
+
     // Check for other relevant interrupts here and do something with that info...
 }
 
@@ -383,200 +500,6 @@ void read_reg(uint8_t reg){
     rp2040_log("read_reg: 0x%02x: 0x%02x\n", reg, return_buf[0]);
 }
 
-static bool max77958_debug_read_gpio_control(max77958_debug_status_t *status)
-{
-    memset(op_code_return_buf, 0, sizeof op_code_return_buf);
-    opcodes_finished = false;
-
-    opcode_queue_add(gpio_control_read, 0);
-    if (!opcode_queue_pop()) {
-        rp2040_log("MAX77958_DIAG: GPIO read queue was empty\n");
-        return false;
-    }
-
-    uint32_t waited_ms = 0;
-    while (!opcodes_finished && waited_ms < 500) {
-        sleep_ms(10);
-        waited_ms += 10;
-    }
-
-    if (!opcodes_finished) {
-        rp2040_log("MAX77958_DIAG: GPIO read timed out\n");
-        return false;
-    }
-
-    if (op_code_return_buf[0] != OPCODE_READ_GPIO) {
-        rp2040_log("MAX77958_DIAG: GPIO read unexpected opcode 0x%02x\n", op_code_return_buf[0]);
-        return false;
-    }
-
-    status->gpio0_3 = op_code_return_buf[1];
-    status->gpio4_7 = op_code_return_buf[2];
-    status->gpio8 = op_code_return_buf[3];
-    status->gpio_valid = true;
-    return true;
-}
-
-static max77958_debug_status_t max77958_debug_read_status(void)
-{
-    max77958_debug_status_t status = {0};
-
-    status.usbc_status1 = max77958_read_register(0x08);
-    status.usbc_status2 = max77958_read_register(0x09);
-    status.bc_status = max77958_read_register(0x0A);
-    status.cc_status0 = max77958_read_register(0x0C);
-    status.cc_status1 = max77958_read_register(0x0D);
-    status.pd_status0 = max77958_read_register(0x0E);
-    status.pd_status1 = max77958_read_register(0x0F);
-    max77958_debug_read_gpio_control(&status);
-
-    return status;
-}
-
-static void max77958_debug_log_status(uint32_t elapsed_ms, const max77958_debug_status_t *status)
-{
-    uint8_t vbadc = (status->usbc_status1 >> 3) & 0x1F;
-    uint8_t cc_pin = (status->cc_status0 >> 6) & 0x03;
-    uint8_t cc_current = (status->cc_status0 >> 4) & 0x03;
-    uint8_t cc_state = status->cc_status0 & 0x07;
-    uint8_t power_role = (status->pd_status1 >> 6) & 0x01;
-    uint8_t data_role = (status->pd_status1 >> 7) & 0x01;
-    uint8_t psrdy = (status->pd_status1 >> 4) & 0x01;
-    uint8_t g4_dir = status->gpio4_7 & 0x01;
-    uint8_t g4_out = (status->gpio4_7 >> 1) & 0x01;
-    uint8_t g5_dir = (status->gpio4_7 >> 2) & 0x01;
-    uint8_t g5_out = (status->gpio4_7 >> 3) & 0x01;
-
-    rp2040_log("MAX77958_DIAG t=%" PRIu32 "ms USBC1=0x%02x VbADC=%u SYS=0x%02x BC=0x%02x\n",
-                elapsed_ms, status->usbc_status1, vbadc, status->usbc_status2, status->bc_status);
-    rp2040_log("MAX77958_DIAG t=%" PRIu32 "ms CC0=0x%02x pin=%u current=%u state=%u(%s)\n",
-                elapsed_ms, status->cc_status0, cc_pin, cc_current, cc_state,
-                cc_state_name(cc_state));
-    rp2040_log("MAX77958_DIAG t=%" PRIu32 "ms CC1=0x%02x wtr=%u detabrt=%u vsafeov=%u\n",
-                elapsed_ms, status->cc_status1,
-                (status->cc_status1 >> 1) & 0x01,
-                (status->cc_status1 >> 2) & 0x01,
-                (status->cc_status1 >> 3) & 0x01);
-    rp2040_log("MAX77958_DIAG t=%" PRIu32 "ms PD0=0x%02x PD1=0x%02x power_raw=%u data=%u(%s) psrdy=%u(%s)\n",
-                elapsed_ms, status->pd_status0, status->pd_status1, power_role,
-                data_role, data_role_name(data_role), psrdy, ready_name(psrdy));
-    rp2040_log("MAX77958_DIAG t=%" PRIu32 "ms GPIO53=0x%02x valid=%u g4=%u/%u g5=%u/%u\n",
-                elapsed_ms, status->gpio4_7, status->gpio_valid ? 1 : 0,
-                g4_dir, g4_out, g5_dir, g5_out);
-}
-
-static bool max77958_debug_queue_data_role_swap_request(uint32_t elapsed_ms)
-{
-    opcodes_finished = false;
-    opcode_queue_add(data_role_swap_request, 0);
-    if (!opcode_queue_pop()) {
-        rp2040_log("MAX77958_DIAG: DR_SWAP retry could not start; opcode queue was empty\n");
-        opcodes_finished = true;
-        return false;
-    }
-
-    uint32_t waited_ms = 0;
-    while (!opcodes_finished && waited_ms < 500) {
-        sleep_ms(10);
-        waited_ms += 10;
-    }
-
-    if (!opcodes_finished) {
-        rp2040_log("MAX77958_DIAG: DR_SWAP retry command timed out at %" PRIu32 "ms\n",
-                    elapsed_ms);
-        opcodes_finished = true;
-        return false;
-    }
-
-    rp2040_log("MAX77958_DIAG: DR_SWAP retry command completed in %" PRIu32 "ms\n",
-                waited_ms);
-    return true;
-}
-
-static void max77958_debug_maybe_retry_data_role_swap(uint32_t elapsed_ms,
-                                                      const max77958_debug_status_t *status)
-{
-    static uint8_t retry_count = 0;
-    static uint32_t last_retry_ms = 0;
-    static bool exhausted_logged = false;
-
-    if (elapsed_ms == 0) {
-        retry_count = 0;
-        last_retry_ms = 0;
-        exhausted_logged = false;
-    }
-
-    uint8_t cc_state = status->cc_status0 & 0x07;
-    bool source_attached = cc_state == CC_STATUS0_STATE_SOURCE;
-    bool dfp = (status->pd_status1 & PD_STATUS1_DATA_ROLE_DFP) != 0;
-    bool psrdy = (status->pd_status1 & PD_STATUS1_PSRDY) != 0;
-
-    if (!source_attached) {
-        return;
-    }
-
-    if (!dfp) {
-        if (retry_count > 0) {
-            rp2040_log("MAX77958_DIAG: DR_SWAP retry succeeded after %u request(s)\n",
-                        retry_count);
-        }
-        retry_count = 0;
-        exhausted_logged = false;
-        return;
-    }
-
-    if (retry_count >= MAX77958_DIAG_DR_SWAP_MAX_RETRIES) {
-        if (!exhausted_logged) {
-            rp2040_log("MAX77958_DIAG: DR_SWAP retry exhausted after %u request(s); still DFP/host\n",
-                        retry_count);
-            exhausted_logged = true;
-        }
-        return;
-    }
-
-    if (retry_count > 0 &&
-        elapsed_ms - last_retry_ms < MAX77958_DIAG_DR_SWAP_RETRY_INTERVAL_MS) {
-        return;
-    }
-
-    retry_count++;
-    last_retry_ms = elapsed_ms;
-    rp2040_log("MAX77958_DIAG: DR_SWAP retry %u/%u at %" PRIu32 "ms with psrdy=%u(%s)\n",
-                retry_count, MAX77958_DIAG_DR_SWAP_MAX_RETRIES, elapsed_ms,
-                psrdy ? 1 : 0, ready_name(psrdy));
-    max77958_debug_queue_data_role_swap_request(elapsed_ms);
-}
-
-void max77958_debug_poll_status(uint32_t duration_ms, uint32_t interval_ms)
-{
-    if (interval_ms == 0) {
-        interval_ms = 1000;
-    }
-
-    rp2040_log("MAX77958_DIAG: begin status poll for %" PRIu32 "ms every %" PRIu32 "ms\n",
-                duration_ms, interval_ms);
-
-    uint32_t elapsed_ms = 0;
-    while (elapsed_ms <= duration_ms) {
-        max77958_debug_status_t status = max77958_debug_read_status();
-        max77958_debug_log_status(elapsed_ms, &status);
-        max77958_debug_maybe_retry_data_role_swap(elapsed_ms, &status);
-
-        if (elapsed_ms == duration_ms) {
-            break;
-        }
-
-        uint32_t sleep_for_ms = interval_ms;
-        if (elapsed_ms + sleep_for_ms > duration_ms) {
-            sleep_for_ms = duration_ms - elapsed_ms;
-        }
-        sleep_ms(sleep_for_ms);
-        elapsed_ms += sleep_for_ms;
-    }
-
-    rp2040_log("MAX77958_DIAG: end status poll\n");
-}
-
 static int opcode_write(uint8_t *buf){
     // buf should always be 32 bytes long since the register values from 0x22 to 0x41 are never overwritten,
     // so you may send wrong data if you don't directly specify them for ALL registers. Note the defaults are NOT always 0x00,
@@ -614,6 +537,65 @@ static void opcode_read(){
     //memset(return_buf, 0, sizeof return_buf);
     //return_buf[0] = 0x21;
     //i2c_write_error_handling(i2c0, MAX77958_SLAVE_P1, return_buf, 32, false);
+}
+
+static bool service_pending_interrupt_snapshot(const char *context, bool log_snapshot)
+{
+    get_interrupt_vals();
+    uint8_t uic_int = return_buf[0];
+    uint8_t cc_int = return_buf[1];
+    uint8_t pd_int = return_buf[2];
+    uint8_t action_int = return_buf[3];
+
+    if (log_snapshot) {
+        rp2040_log("MAX77958_DIAG: %s interrupt snapshot INTB=%u UIC_INT=0x%02x CC_INT=0x%02x PD_INT=0x%02x ACTION_INT=0x%02x opcode_queue=%u\n",
+                   context, gpio_get(_gpio_interrupt), uic_int, cc_int, pd_int, action_int,
+                   queue_get_level(&opcode_queue));
+    }
+
+    if (uic_int == 0 && cc_int == 0 && pd_int == 0 && action_int == 0) {
+        return false;
+    }
+
+    handle_interrupt_vals(uic_int, cc_int, pd_int);
+    return true;
+}
+
+static bool wait_for_opcode_response(const char *context, uint32_t timeout_ms)
+{
+    uint32_t waited_ms = 0;
+    uint32_t next_drain_ms = 0;
+    bool logged_intb_low = false;
+
+    while (!opcodes_finished && waited_ms < timeout_ms) {
+        if (gpio_get(_gpio_interrupt) == 0 && waited_ms >= next_drain_ms) {
+            if (!logged_intb_low) {
+                rp2040_log("MAX77958_DIAG: %s opcode wait saw INTB low; queueing interrupt drain\n", context);
+                logged_intb_low = true;
+            }
+            call_queue_try_add(&parse_interrupt_vals, 0);
+            next_drain_ms = waited_ms + MAX77958_OPCODE_WAIT_DRAIN_MS;
+        }
+
+        sleep_ms(MAX77958_OPCODE_WAIT_POLL_MS);
+        waited_ms += MAX77958_OPCODE_WAIT_POLL_MS;
+    }
+
+    if (opcodes_finished) {
+        return true;
+    }
+
+    rp2040_log("MAX77958_DIAG: %s opcode wait timed out after %" PRIu32 "ms; checking pending interrupts directly\n",
+               context, waited_ms);
+    service_pending_interrupt_snapshot(context, true);
+
+    if (opcodes_finished) {
+        rp2040_log("MAX77958_DIAG: %s opcode wait recovered from pending interrupt snapshot\n", context);
+        return true;
+    }
+
+    rp2040_log("MAX77958_DIAG: %s opcode wait failed after pending interrupt snapshot\n", context);
+    return false;
 }
 
 static uint8_t max77958_read_register(uint8_t reg)
@@ -684,13 +666,8 @@ void test_max77958_bc_ctrl1_read(){
     rp2040_log("test_max77958_bc_ctrl1_read started...\n");
     opcode_queue_add(bc_ctrl1_read, 0);
     opcode_queue_pop();
-    int i = 0;
-    while (!opcodes_finished){
-	sleep_ms(100);
-	i++;
-	if (i > 10){
-	    rp2040_log("test_max77958_bc_ctrl1_read ERROR: Timed out waiting for GPIO to finish\n");
-	}
+    if (!wait_for_opcode_response("test_max77958_bc_ctrl1_read", MAX77958_OPCODE_WAIT_TIMEOUT_MS)) {
+        return;
     }
     if (op_code_return_buf[0] != 0x01){
 	rp2040_log("test_max77958_bc_ctrl1_read ERROR: OPCODE should be 0x01");
@@ -721,12 +698,8 @@ void test_max77958_bc_ctrl2_read(void)
     opcode_queue_add(bc_ctrl2_read, 0);
     opcode_queue_pop();
 
-    int i = 0;
-    while (!opcodes_finished) {
-        sleep_ms(100);
-        if (++i > 10) {
-            rp2040_log("test_max77958_bc_ctrl2_read ERROR: Timed out waiting for response\n");
-        }
+    if (!wait_for_opcode_response("test_max77958_bc_ctrl2_read", MAX77958_OPCODE_WAIT_TIMEOUT_MS)) {
+        return;
     }
 
     if (op_code_return_buf[0] != 0x03) {
@@ -761,12 +734,8 @@ void test_max77958_control1_read(void)
     opcode_queue_add(control1_read, 0);
     opcode_queue_pop();
 
-    int i = 0;
-    while (!opcodes_finished) {
-        sleep_ms(100);
-        if (++i > 10) {
-            rp2040_log("test_max77958_control1_read ERROR: Timed out waiting for response\n");
-        }
+    if (!wait_for_opcode_response("test_max77958_control1_read", MAX77958_OPCODE_WAIT_TIMEOUT_MS)) {
+        return;
     }
 
     if (op_code_return_buf[0] != 0x05) {
@@ -808,13 +777,8 @@ void test_max77958_cc_ctrl1_read(){
     rp2040_log("test_max77958_cc_ctrl1_read started...\n");
     opcode_queue_add(cc_ctrl1_read, 0);
     opcode_queue_pop();
-    int i = 0;
-    while (!opcodes_finished){
-	sleep_ms(100);
-	i++;
-	if (i > 10){
-	    rp2040_log("test_max77958_cc_ctrl1_read ERROR: Timed out waiting for GPIO to finish\n");
-	}
+    if (!wait_for_opcode_response("test_max77958_cc_ctrl1_read", MAX77958_OPCODE_WAIT_TIMEOUT_MS)) {
+        return;
     }
     if (op_code_return_buf[0] != 0x0B){
 	rp2040_log("test_max77958_cc_ctrl1_read ERROR: OPCODE should be 0x0B");
@@ -846,12 +810,8 @@ void test_max77958_cc_ctrl4_read(void)
     opcode_queue_add(cc_ctrl4_read, 0);
     opcode_queue_pop();
 
-    int i = 0;
-    while (!opcodes_finished) {
-        sleep_ms(100);
-        if (++i > 10) {
-            rp2040_log("test_max77958_cc_ctrl4_read ERROR: Timed out waiting for response\n");
-        }
+    if (!wait_for_opcode_response("test_max77958_cc_ctrl4_read", MAX77958_OPCODE_WAIT_TIMEOUT_MS)) {
+        return;
     }
 
     if (op_code_return_buf[0] != 0x11) {
@@ -885,12 +845,8 @@ void test_max77958_gpio_control_read(void)
     opcode_queue_add(gpio_control_read, 0);
     opcode_queue_pop();
 
-    int i = 0;
-    while (!opcodes_finished) {
-        sleep_ms(100);
-        if (++i > 10) {
-            rp2040_log("test_max77958_gpio_control_read ERROR: Timed out waiting for response\n");
-        }
+    if (!wait_for_opcode_response("test_max77958_gpio_control_read", MAX77958_OPCODE_WAIT_TIMEOUT_MS)) {
+        return;
     }
 
     if (op_code_return_buf[0] != 0x23) {
@@ -945,12 +901,8 @@ void test_max77958_gpio0_gpio1_adc_read(void)
     opcode_queue_add(gpio0_gpio1_adc_read, 0);
     opcode_queue_pop();
 
-    int i = 0;
-    while (!opcodes_finished) {
-        sleep_ms(100);
-        if (++i > 10) {
-            rp2040_log("test_max77958_gpio0_gpio1_adc_read ERROR: Timed out waiting for response\n");
-        }
+    if (!wait_for_opcode_response("test_max77958_gpio0_gpio1_adc_read", MAX77958_OPCODE_WAIT_TIMEOUT_MS)) {
+        return;
     }
 
     if (op_code_return_buf[0] != 0x27) {
@@ -997,12 +949,8 @@ void test_max77958_snk_pdo_request(void)
     use_mtp_access = false;  // for RAM access
     opcode_queue_add(snk_pdo_request, 0);
     opcode_queue_pop();
-    int i = 0;
-    while (!opcodes_finished) {
-        sleep_ms(100);
-        if (++i > 10) {
-            rp2040_log("test_max77958_snk_pdo_request ERROR: Timed out waiting for MTP\n");
-        }
+    if (!wait_for_opcode_response("test_max77958_snk_pdo_request MTP", MAX77958_OPCODE_WAIT_TIMEOUT_MS)) {
+        return;
     }
     if (op_code_return_buf[0] != 0x3E) {
         rp2040_log("test_max77958_snk_pdo_request ERROR: OPCODE echo mismatch for MTP (got 0x%02x)\n",
@@ -1023,12 +971,8 @@ void test_max77958_snk_pdo_request(void)
     use_mtp_access = true;  // for RAM access
     opcode_queue_add(snk_pdo_request, 0);
     opcode_queue_pop();
-    i = 0;
-    while (!opcodes_finished) {
-        sleep_ms(100);
-        if (++i > 10) {
-            rp2040_log("test_max77958_snk_pdo_request ERROR: Timed out waiting for RAM\n");
-        }
+    if (!wait_for_opcode_response("test_max77958_snk_pdo_request RAM", MAX77958_OPCODE_WAIT_TIMEOUT_MS)) {
+        return;
     }
     if (op_code_return_buf[0] != 0x3E) {
         rp2040_log("test_max77958_snk_pdo_request ERROR: OPCODE echo mismatch for RAM (got 0x%02x)\n",
@@ -1062,13 +1006,8 @@ void test_max77958_get_customer_config(){
     rp2040_log("test_max77958_get_customer_config started...\n");
     opcode_queue_add(customer_config_read, 0);
     opcode_queue_pop();
-    int i = 0;
-    while (!opcodes_finished){
-	sleep_ms(100);
-	i++;
-	if (i > 10){
-	    rp2040_log("test_max77958_get_customer_config ERROR: Timed out waiting for GPIO to finish\n");
-	}
+    if (!wait_for_opcode_response("test_max77958_get_customer_config", MAX77958_OPCODE_WAIT_TIMEOUT_MS)) {
+        return;
     }
     if (op_code_return_buf[0] != 0x55){
 	rp2040_log("test_max77958_get_customer_config ERROR: OPCODE should be 0x55");
@@ -1168,17 +1107,13 @@ void max77958_init(uint gpio_interrupt, queue_t* cq, queue_t* rq){
     //opcode_queue_add(set_snk_pdos, 0);
     //opcode_queue_add(set_src_pdos, 0);
 
+    init_config_pending = true;
     opcode_queue_pop();
 #ifdef MAX77958_FORCE_VBUS_DIAGNOSTIC
-    uint32_t waited_ms = 0;
-    while (!opcodes_finished && waited_ms < 3000) {
-        sleep_ms(10);
-        waited_ms += 10;
-    }
-    if (opcodes_finished) {
-        rp2040_log("MAX77958_DIAG: init opcode queue finished after %" PRIu32 "ms\n", waited_ms);
+    if (wait_for_opcode_response("max77958_init", 3000)) {
+        rp2040_log("MAX77958_DIAG: init opcode queue finished\n");
     } else {
-        rp2040_log("MAX77958_DIAG: init opcode queue timed out after %" PRIu32 "ms\n", waited_ms);
+        rp2040_log("MAX77958_DIAG: init opcode queue timed out\n");
     }
 #endif
     rp2040_log("max77958 init finished\n");
@@ -1308,12 +1243,15 @@ static int32_t gpio_set(int32_t gpio_val){
     return 0;
 }
 
-static void power_swap_request(){
+static int32_t power_swap_request(void)
+{
     memset(send_buf, 0, sizeof send_buf);
     send_buf[0] = OPCODE_WRITE;
     send_buf[1] = OPCODE_SWAP_REQ;
     send_buf[2] = MAX77958_SWAP_REQ_PR_SWAP;
+    rp2040_log("MAX77958_DIAG: requesting PR_SWAP to source phone power\n");
     opcode_write(send_buf);
+    return 0;
 }
 
 static int32_t swap_response_write(void)
@@ -1339,26 +1277,247 @@ static int32_t data_role_swap_request(void)
     return 0;
 }
 
+static bool evaluate_current_role_state(const char *reason)
+{
+    if (init_config_pending) {
+        rp2040_log("MAX77958_DIAG: state evaluation deferred for %s; init config still pending\n",
+                    reason);
+        return false;
+    }
+
+    max77958_role_state_t state = max77958_read_role_state();
+    log_role_state("state eval", reason, &state);
+
+    if (!state.attached) {
+        rp2040_log("MAX77958_DIAG: role case: not attached or not in a usable attached state\n");
+        power_role_swap_request_count = 0;
+        source_dfp_not_ready_recheck_count = 0;
+        post_prswap_vbus_recheck_count = 0;
+        vbus_turn_off();
+        return false;
+    }
+
+    if (state.pcb_power == MAX77958_PCB_POWER_SINK) {
+        source_dfp_not_ready_recheck_count = 0;
+        if (!state.pd_ready) {
+            rp2040_log("MAX77958_DIAG: role case: pcb_power=SINK; waiting for PD ready\n");
+            return false;
+        }
+
+        if (state.pcb_data == MAX77958_PCB_DATA_DFP_HOST) {
+            rp2040_log("MAX77958_DIAG: role case: pcb_power=SINK pcb_data=DFP_HOST; requesting DR_SWAP\n");
+            return queue_data_role_swap_to_ufp_if_ready(reason);
+        }
+
+        rp2040_log("MAX77958_DIAG: role case: pcb_power=SINK pcb_data=UFP_DEVICE; requesting PR_SWAP\n");
+        return queue_power_role_swap_to_source_if_ready(reason);
+    }
+
+    if (state.pcb_power == MAX77958_PCB_POWER_SOURCE) {
+        power_role_swap_request_count = 0;
+        if (state.pcb_data == MAX77958_PCB_DATA_DFP_HOST) {
+            if (!state.pd_ready) {
+                rp2040_log("MAX77958_DIAG: role case: pcb_power=SOURCE pcb_data=DFP_HOST; waiting for PD ready before DR_SWAP\n");
+                vbus_turn_on();
+                schedule_delayed_role_recheck(MAX77958_RECHECK_SOURCE_DFP_NOT_READY);
+                return false;
+            }
+
+            source_dfp_not_ready_recheck_count = 0;
+            rp2040_log("MAX77958_DIAG: role case: pcb_power=SOURCE pcb_data=DFP_HOST; enabling VBUS and requesting DR_SWAP\n");
+            vbus_turn_on();
+            return queue_data_role_swap_to_ufp_if_ready(reason);
+        }
+
+        source_dfp_not_ready_recheck_count = 0;
+        rp2040_log("MAX77958_DIAG: role case: pcb_power=SOURCE pcb_data=UFP_DEVICE; ensuring VBUS on\n");
+        vbus_turn_on();
+        return false;
+    }
+
+    return false;
+}
+
+void max77958_on_start_complete(void)
+{
+    evaluate_current_role_state("post on_start complete");
+}
+
+static bool queue_power_role_swap_to_source_if_ready(const char *reason)
+{
+    if (init_config_pending) {
+        rp2040_log("MAX77958_DIAG: PR_SWAP deferred for %s; init config still pending\n", reason);
+        return false;
+    }
+
+    max77958_role_state_t state = max77958_read_role_state();
+    log_role_state("PR_SWAP check", reason, &state);
+    rp2040_log("MAX77958_DIAG: PR_SWAP retry=%u/%u\n",
+                power_role_swap_request_count, MAX77958_PR_SWAP_MAX_RETRIES);
+
+    if (state.pcb_power == MAX77958_PCB_POWER_SOURCE) {
+        power_role_swap_request_count = 0;
+        return false;
+    }
+
+    if (state.pcb_power != MAX77958_PCB_POWER_SINK ||
+        state.pcb_data != MAX77958_PCB_DATA_UFP_DEVICE ||
+        !state.pd_ready) {
+        return false;
+    }
+
+    if (power_role_swap_request_count >= MAX77958_PR_SWAP_MAX_RETRIES) {
+        rp2040_log("MAX77958_DIAG: PR_SWAP retry exhausted; staying sink/UFP for Android host compatibility\n");
+        return false;
+    }
+
+    power_role_swap_request_count++;
+    opcode_queue_add(power_swap_request, 0);
+    return true;
+}
+
+static bool queue_data_role_swap_to_ufp_if_ready(const char *reason)
+{
+    if (data_role_swap_requested) {
+        return false;
+    }
+
+    max77958_role_state_t state = max77958_read_role_state();
+    log_role_state("DR_SWAP check", reason, &state);
+
+    if (!state.attached ||
+        state.pcb_data != MAX77958_PCB_DATA_DFP_HOST ||
+        !state.pd_ready) {
+        return false;
+    }
+
+    data_role_swap_requested = true;
+    opcode_queue_add(data_role_swap_request, 0);
+    return true;
+}
+
+static bool queue_vbus_on_after_pr_swap_if_source_attached(void)
+{
+    max77958_role_state_t state = max77958_read_role_state();
+
+    log_role_state("post PR_SWAP VBUS check", "PR_SWAP", &state);
+    rp2040_log("MAX77958_DIAG: post PR_SWAP VBUS requested=%u\n",
+                vbus_enable_requested ? 1 : 0);
+
+    if (vbus_enable_requested) {
+        post_prswap_vbus_recheck_count = 0;
+        rp2040_log("MAX77958_DIAG: post PR_SWAP VBUS already requested; stopping recheck\n");
+        return true;
+    }
+
+    if (state.pcb_power != MAX77958_PCB_POWER_SOURCE) {
+        return false;
+    }
+
+    rp2040_log("MAX77958_DIAG: post PR_SWAP source attached; enabling VBUS GPIO4/GPIO5\n");
+    vbus_turn_on();
+    return true;
+}
+
+static int64_t delayed_role_recheck_alarm(alarm_id_t id, void *user_data)
+{
+    (void)id;
+
+    if (call_queue_ptr != NULL) {
+        queue_entry_t entry = {delayed_role_recheck, (int32_t)(intptr_t)user_data};
+        queue_try_add(call_queue_ptr, &entry);
+    }
+
+    return 0;
+}
+
+static void schedule_delayed_role_recheck(int32_t reason)
+{
+    bool *pending = NULL;
+    uint8_t *count = NULL;
+    uint8_t max_rechecks = 0;
+    const char *name = "unknown";
+
+    switch (reason) {
+        case MAX77958_RECHECK_SOURCE_DFP_NOT_READY:
+            pending = &source_dfp_not_ready_recheck_pending;
+            count = &source_dfp_not_ready_recheck_count;
+            max_rechecks = MAX77958_SOURCE_DFP_NOT_READY_MAX_RECHECKS;
+            name = "SOURCE_DFP_NOT_READY";
+            break;
+        case MAX77958_RECHECK_POST_PRSWAP_VBUS:
+            pending = &post_prswap_vbus_recheck_pending;
+            count = &post_prswap_vbus_recheck_count;
+            max_rechecks = MAX77958_POST_PRSWAP_VBUS_MAX_RECHECKS;
+            name = "POST_PRSWAP_VBUS";
+            break;
+        default:
+            rp2040_log("MAX77958_DIAG: unknown delayed role recheck reason=%d\n", reason);
+            return;
+    }
+
+    if (*pending) {
+        return;
+    }
+
+    if (*count >= max_rechecks) {
+        rp2040_log("MAX77958_DIAG: delayed role recheck exhausted reason=%s count=%u/%u\n",
+                    name, *count, max_rechecks);
+        return;
+    }
+
+    (*count)++;
+    *pending = true;
+    rp2040_log("MAX77958_DIAG: scheduling delayed role recheck reason=%s count=%u/%u delay_ms=%u\n",
+                name, *count, max_rechecks, MAX77958_ROLE_RECHECK_DELAY_MS);
+    if (add_alarm_in_ms(MAX77958_ROLE_RECHECK_DELAY_MS,
+                        delayed_role_recheck_alarm,
+                        (void *)(intptr_t)reason,
+                        false) < 0) {
+        *pending = false;
+        rp2040_log("MAX77958_DIAG: failed to schedule delayed role recheck reason=%s\n", name);
+    }
+}
+
+static int32_t delayed_role_recheck(int32_t reason)
+{
+    switch (reason) {
+        case MAX77958_RECHECK_SOURCE_DFP_NOT_READY:
+            source_dfp_not_ready_recheck_pending = false;
+            if (evaluate_current_role_state("delayed SOURCE/DFP wait")) {
+                opcode_queue_pop();
+            }
+            break;
+        case MAX77958_RECHECK_POST_PRSWAP_VBUS:
+            post_prswap_vbus_recheck_pending = false;
+            if (queue_vbus_on_after_pr_swap_if_source_attached()) {
+                post_prswap_vbus_recheck_count = 0;
+                break;
+            }
+            schedule_delayed_role_recheck(MAX77958_RECHECK_POST_PRSWAP_VBUS);
+            break;
+        default:
+            rp2040_log("MAX77958_DIAG: delayed role recheck unknown reason=%d\n", reason);
+            break;
+    }
+
+    return 0;
+}
+
 static bool queue_data_role_swap_to_ufp_once(void)
 {
     if (data_role_swap_requested) {
         return false;
     }
 
-    uint8_t cc_status0 = max77958_read_register(REG_CC_STATUS0);
-    uint8_t pd_status1 = max77958_read_register(REG_PD_STATUS1);
-    bool source_attached = (cc_status0 & 0x07) == CC_STATUS0_STATE_SOURCE;
-    bool dfp = (pd_status1 & PD_STATUS1_DATA_ROLE_DFP) != 0;
-    bool psrdy = (pd_status1 & PD_STATUS1_PSRDY) != 0;
+    max77958_role_state_t state = max77958_read_role_state();
+    log_role_state("DR_SWAP check", "VBUS on", &state);
 
-    rp2040_log("MAX77958_DIAG: DR_SWAP check CC0=0x%02x source=%u PD1=0x%02x data=%u psrdy=%u\n",
-                cc_status0, source_attached ? 1 : 0, pd_status1, dfp ? 1 : 0, psrdy ? 1 : 0);
-
-    if (!source_attached || !psrdy) {
+    if (state.pcb_power != MAX77958_PCB_POWER_SOURCE || !state.pd_ready) {
         return false;
     }
 
-    if (!dfp) {
+    if (state.pcb_data != MAX77958_PCB_DATA_DFP_HOST) {
         rp2040_log("MAX77958_DIAG: data role already UFP/device\n");
         data_role_swap_requested = true;
         return false;
@@ -1450,7 +1609,9 @@ static void vbus_turn_off(){
     rp2040_log("MAX77958_DIAG: forced VBUS mode ignoring vbus_turn_off\n");
     return;
 #endif
+    rp2040_log("MAX77958_DIAG: setting VBUS GPIO4/GPIO5 off\n");
     data_role_swap_requested = false;
+    vbus_enable_requested = false;
     opcode_queue_add(&gpio_set, gpio_bool_to_int32(false, false));
     opcode_queue_pop();
 }
@@ -1464,6 +1625,8 @@ static int32_t force_vbus_on_for_diagnostic(void)
 #endif
 
 static void vbus_turn_on(){
+    rp2040_log("MAX77958_DIAG: setting VBUS GPIO4/GPIO5 on\n");
+    vbus_enable_requested = true;
     opcode_queue_add(&gpio_set, gpio_bool_to_int32(true, true));
     queue_data_role_swap_to_ufp_once();
     opcode_queue_pop();
@@ -1483,6 +1646,9 @@ static int32_t pd_msg_response(){
 	    break;
         case PDMSG_REJECT_RECEIVED:
 	    rp2040_log("PD Message: REJECT_RECEIVED\n");
+            if (evaluate_current_role_state("PD reject")) {
+                opcode_queue_pop();
+            }
 	    break;
         case PDMSG_PRSWAP_SRCTOSWAP:
 	    rp2040_log("PD Message: PRSWAP_SRCTOSWAP\n");
@@ -1493,6 +1659,7 @@ static int32_t pd_msg_response(){
 	    break;
 	case PDMSG_PRSWAP_SNKTOSWAP:
 	    rp2040_log("PD Message: PRSWAP_SNKTOSWAP\n");
+            schedule_delayed_role_recheck(MAX77958_RECHECK_POST_PRSWAP_VBUS);
 	    break;
 	case PDMSG_PRSWAP_SWAPTOSRC:
 	    rp2040_log("PD Message: PRSWAP_SWAPTOSRC\n");
@@ -1525,12 +1692,7 @@ static int32_t pd_msg_response(){
 void max77958_shutdown(uint gpio_interrupt){
     opcode_queue_add(gpio_set, gpio_bool_to_int32(false, false));
     opcode_queue_pop();
-    int i = 0;
-    while (!opcodes_finished){
-	sleep_ms(100);
-	i++;
-	if (i > 10){
-	    rp2040_log("ERROR: Timed out waiting for GPIO to finish\n");
-	}
+    if (!wait_for_opcode_response("max77958_shutdown", MAX77958_OPCODE_WAIT_TIMEOUT_MS)) {
+        rp2040_log("ERROR: max77958_shutdown timed out waiting for VBUS GPIO command\n");
     }
 }

--- a/src/max77958.c
+++ b/src/max77958.c
@@ -22,6 +22,8 @@ static uint8_t op_code_return_buf[33] = {0}; // Will read full buffer from regis
 #define CC_STATUS0_STATE_SOURCE 0x02
 #define PD_STATUS1_DATA_ROLE_DFP (1u << 7)
 #define PD_STATUS1_PSRDY (1u << 4)
+#define MAX77958_DIAG_DR_SWAP_RETRY_INTERVAL_MS 1000
+#define MAX77958_DIAG_DR_SWAP_MAX_RETRIES 10
 static queue_t* call_queue_ptr;
 static queue_t* return_queue_ptr;
 static bool opcode_cmd_finished = false;
@@ -95,6 +97,9 @@ typedef struct {
     uint8_t gpio8;
     bool gpio_valid;
 } max77958_debug_status_t;
+
+static void max77958_debug_maybe_retry_data_role_swap(uint32_t elapsed_ms,
+                                                      const max77958_debug_status_t *status);
 
 static const char *cc_state_name(uint8_t state)
 {
@@ -460,6 +465,88 @@ static void max77958_debug_log_status(uint32_t elapsed_ms, const max77958_debug_
                 g4_dir, g4_out, g5_dir, g5_out);
 }
 
+static bool max77958_debug_queue_data_role_swap_request(uint32_t elapsed_ms)
+{
+    opcodes_finished = false;
+    opcode_queue_add(data_role_swap_request, 0);
+    if (!opcode_queue_pop()) {
+        rp2040_log("MAX77958_DIAG: DR_SWAP retry could not start; opcode queue was empty\n");
+        opcodes_finished = true;
+        return false;
+    }
+
+    uint32_t waited_ms = 0;
+    while (!opcodes_finished && waited_ms < 500) {
+        sleep_ms(10);
+        waited_ms += 10;
+    }
+
+    if (!opcodes_finished) {
+        rp2040_log("MAX77958_DIAG: DR_SWAP retry command timed out at %" PRIu32 "ms\n",
+                    elapsed_ms);
+        opcodes_finished = true;
+        return false;
+    }
+
+    rp2040_log("MAX77958_DIAG: DR_SWAP retry command completed in %" PRIu32 "ms\n",
+                waited_ms);
+    return true;
+}
+
+static void max77958_debug_maybe_retry_data_role_swap(uint32_t elapsed_ms,
+                                                      const max77958_debug_status_t *status)
+{
+    static uint8_t retry_count = 0;
+    static uint32_t last_retry_ms = 0;
+    static bool exhausted_logged = false;
+
+    if (elapsed_ms == 0) {
+        retry_count = 0;
+        last_retry_ms = 0;
+        exhausted_logged = false;
+    }
+
+    uint8_t cc_state = status->cc_status0 & 0x07;
+    bool source_attached = cc_state == CC_STATUS0_STATE_SOURCE;
+    bool dfp = (status->pd_status1 & PD_STATUS1_DATA_ROLE_DFP) != 0;
+    bool psrdy = (status->pd_status1 & PD_STATUS1_PSRDY) != 0;
+
+    if (!source_attached) {
+        return;
+    }
+
+    if (!dfp) {
+        if (retry_count > 0) {
+            rp2040_log("MAX77958_DIAG: DR_SWAP retry succeeded after %u request(s)\n",
+                        retry_count);
+        }
+        retry_count = 0;
+        exhausted_logged = false;
+        return;
+    }
+
+    if (retry_count >= MAX77958_DIAG_DR_SWAP_MAX_RETRIES) {
+        if (!exhausted_logged) {
+            rp2040_log("MAX77958_DIAG: DR_SWAP retry exhausted after %u request(s); still DFP/host\n",
+                        retry_count);
+            exhausted_logged = true;
+        }
+        return;
+    }
+
+    if (retry_count > 0 &&
+        elapsed_ms - last_retry_ms < MAX77958_DIAG_DR_SWAP_RETRY_INTERVAL_MS) {
+        return;
+    }
+
+    retry_count++;
+    last_retry_ms = elapsed_ms;
+    rp2040_log("MAX77958_DIAG: DR_SWAP retry %u/%u at %" PRIu32 "ms with psrdy=%u(%s)\n",
+                retry_count, MAX77958_DIAG_DR_SWAP_MAX_RETRIES, elapsed_ms,
+                psrdy ? 1 : 0, ready_name(psrdy));
+    max77958_debug_queue_data_role_swap_request(elapsed_ms);
+}
+
 void max77958_debug_poll_status(uint32_t duration_ms, uint32_t interval_ms)
 {
     if (interval_ms == 0) {
@@ -473,6 +560,7 @@ void max77958_debug_poll_status(uint32_t duration_ms, uint32_t interval_ms)
     while (elapsed_ms <= duration_ms) {
         max77958_debug_status_t status = max77958_debug_read_status();
         max77958_debug_log_status(elapsed_ms, &status);
+        max77958_debug_maybe_retry_data_role_swap(elapsed_ms, &status);
 
         if (elapsed_ms == duration_ms) {
             break;

--- a/src/robot.c
+++ b/src/robot.c
@@ -229,9 +229,6 @@ void on_start(){
     sn74ahc125rgyr_init(SN74AHC125RGYR_GPIO1);
     sn74ahc125rgyr_init(SN74AHC125RGYR_GPIO2);
     max77958_init(MAX77958_INTB, &call_queue, &results_queue);
-    #ifdef LOGGER_UART
-    max77958_debug_poll_status(MAX77958_DIAG_POLL_MS, 250);
-    #endif
     #endif
 
     sleep_ms(1000);
@@ -283,6 +280,7 @@ void on_start(){
     #endif
 
     rp2040_log("on_start complete\n");
+    max77958_on_start_complete();
     //while(!stdio_usb_connected()){
     //    sleep_ms(100);
     //}

--- a/src/robot.c
+++ b/src/robot.c
@@ -230,7 +230,7 @@ void on_start(){
     sn74ahc125rgyr_init(SN74AHC125RGYR_GPIO2);
     max77958_init(MAX77958_INTB, &call_queue, &results_queue);
     #ifdef LOGGER_UART
-    max77958_debug_poll_status(2000, 250);
+    max77958_debug_poll_status(MAX77958_DIAG_POLL_MS, 250);
     #endif
     #endif
 

--- a/src/robot.c
+++ b/src/robot.c
@@ -63,6 +63,17 @@ void get_motor_faults(RP2040_STATE* state);
 void get_charger_state(RP2040_STATE* state);
 void turn_on_leds();
 uint8_t* i2c_scan(i2c_inst_t *i2c);
+#ifdef EXTERNAL_MAX77958_TEST
+static void external_max77958_i2c1_test(void);
+static bool external_max77958_i2c1_read_register(uint8_t reg, uint8_t *dst, size_t len);
+static bool external_max77958_i2c1_opcode_write(const uint8_t *command);
+static bool external_max77958_i2c1_opcode_read(uint8_t *response, size_t len);
+static bool external_max77958_i2c1_write_customer_config(void);
+static bool external_max77958_i2c1_write_cc_ctrl1_src(void);
+static bool external_max77958_i2c1_read_cc_ctrl1(void);
+static bool external_max77958_i2c1_set_gpio(bool gpio4, bool gpio5);
+static void external_max77958_i2c1_log_status(uint32_t elapsed_ms);
+#endif
 
 volatile CEXCEPTION_T e;
 
@@ -206,6 +217,10 @@ void on_start(){
 
     #ifndef BOARD_PICO
     i2c_start();
+    #ifdef EXTERNAL_MAX77958_TEST
+    external_max77958_i2c1_test();
+    return;
+    #endif
     adc_init();
     turn_on_leds();
     STWLC38JRM_init(WIRELESS_CHG_EN, WIRELESS_CHG_VRECT);
@@ -369,6 +384,266 @@ void i2c_stop(){
     i2c_deinit(i2c0);
     i2c_deinit(i2c1);
 }
+
+#ifdef EXTERNAL_MAX77958_TEST
+#define EXT_MAX77958_ADDR 0x25
+#define EXT_MAX77958_OPCODE_WRITE 0x21
+#define EXT_MAX77958_OPCODE_READ 0x51
+#define EXT_MAX77958_OPCODE_GPIO_READ 0x23
+#define EXT_MAX77958_OPCODE_GPIO_WRITE 0x24
+#define EXT_MAX77958_OPCODE_CC_CTRL1_READ 0x0B
+#define EXT_MAX77958_OPCODE_CC_CTRL1_WRITE 0x0C
+#define EXT_MAX77958_OPCODE_CUSTOMER_CONFIG_WRITE 0x56
+#define EXT_MAX77958_STATUS_POLL_MS 4000
+#define EXT_MAX77958_STATUS_INTERVAL_MS 250
+
+static void external_max77958_i2c1_test(void)
+{
+    uint8_t id[2] = {0x00, 0x00};
+    bool vbus_enabled = false;
+
+    rp2040_log("EXT_MAX77958_I2C1_TEST: begin addr=0x%02x sda=%u scl=%u\n",
+                EXT_MAX77958_ADDR, I2C_SDA1, I2C_SCL1);
+
+    if (!external_max77958_i2c1_read_register(0x00, id, sizeof id)) {
+        rp2040_log("EXT_MAX77958_I2C1_TEST: end\n");
+        return;
+    }
+
+    rp2040_log("EXT_MAX77958_I2C1_TEST: DEVICE_ID=0x%02x DEVICE_REV=0x%02x %s\n",
+                id[0], id[1], (id[0] == 0x58 && id[1] == 0x02) ? "PASS" : "FAIL");
+
+    if (id[0] != 0x58 || id[1] != 0x02) {
+        rp2040_log("EXT_MAX77958_I2C1_TEST: end\n");
+        return;
+    }
+
+    external_max77958_i2c1_log_status(0);
+
+    rp2040_log("EXT_MAX77958_I2C1_TEST: forcing GPIO4/GPIO5 low before source config\n");
+    if (!external_max77958_i2c1_set_gpio(false, false)) {
+        rp2040_log("EXT_MAX77958_I2C1_TEST: end\n");
+        return;
+    }
+    sleep_ms(100);
+    external_max77958_i2c1_log_status(100);
+
+    if (!external_max77958_i2c1_write_customer_config()) {
+        rp2040_log("EXT_MAX77958_I2C1_TEST: end\n");
+        return;
+    }
+    sleep_ms(100);
+
+    if (!external_max77958_i2c1_write_cc_ctrl1_src()) {
+        rp2040_log("EXT_MAX77958_I2C1_TEST: end\n");
+        return;
+    }
+    sleep_ms(100);
+
+    external_max77958_i2c1_read_cc_ctrl1();
+
+    for (uint32_t elapsed_ms = 0;
+         elapsed_ms <= EXT_MAX77958_STATUS_POLL_MS;
+         elapsed_ms += EXT_MAX77958_STATUS_INTERVAL_MS) {
+        uint8_t cc_status0 = 0;
+
+        external_max77958_i2c1_log_status(elapsed_ms);
+        if (!vbus_enabled &&
+            external_max77958_i2c1_read_register(0x0C, &cc_status0, 1) &&
+            (cc_status0 & 0x07) == 0x02) {
+            rp2040_log("EXT_MAX77958_I2C1_TEST: source attach detected, enabling GPIO4/GPIO5\n");
+            if (external_max77958_i2c1_set_gpio(true, true)) {
+                vbus_enabled = true;
+            }
+        }
+
+        if (elapsed_ms == EXT_MAX77958_STATUS_POLL_MS) {
+            break;
+        }
+        sleep_ms(EXT_MAX77958_STATUS_INTERVAL_MS);
+    }
+
+    rp2040_log("EXT_MAX77958_I2C1_TEST: vbus_enabled=%u\n", vbus_enabled ? 1 : 0);
+    rp2040_log("EXT_MAX77958_I2C1_TEST: end\n");
+}
+
+static bool external_max77958_i2c1_read_register(uint8_t reg, uint8_t *dst, size_t len)
+{
+    int write_result = i2c_write_timeout_us(i2c1, EXT_MAX77958_ADDR, &reg, 1, true, I2C_TIMEOUT);
+    if (write_result != 1) {
+        rp2040_log("EXT_MAX77958_I2C1_TEST: FAIL reg=0x%02x write_result=%d\n", reg, write_result);
+        return false;
+    }
+
+    int read_result = i2c_read_timeout_us(i2c1, EXT_MAX77958_ADDR, dst, len, false, I2C_TIMEOUT);
+    if (read_result != (int)len) {
+        rp2040_log("EXT_MAX77958_I2C1_TEST: FAIL reg=0x%02x read_result=%d expected=%u\n",
+                    reg, read_result, (unsigned)len);
+        return false;
+    }
+
+    return true;
+}
+
+static bool external_max77958_i2c1_opcode_write(const uint8_t *command)
+{
+    uint8_t write_end[] = {0x41, 0x00};
+    int write_result = i2c_write_timeout_us(i2c1, EXT_MAX77958_ADDR, command, 33, false, I2C_TIMEOUT);
+    if (write_result != 33) {
+        rp2040_log("EXT_MAX77958_I2C1_TEST: FAIL opcode=0x%02x write_result=%d\n",
+                    command[1], write_result);
+        return false;
+    }
+
+    int end_result = i2c_write_timeout_us(i2c1, EXT_MAX77958_ADDR, write_end, sizeof write_end, false, I2C_TIMEOUT);
+    if (end_result != (int)sizeof write_end) {
+        rp2040_log("EXT_MAX77958_I2C1_TEST: FAIL opcode=0x%02x end_result=%d\n",
+                    command[1], end_result);
+        return false;
+    }
+
+    return true;
+}
+
+static bool external_max77958_i2c1_opcode_read(uint8_t *response, size_t len)
+{
+    uint8_t reg = EXT_MAX77958_OPCODE_READ;
+    int write_result = i2c_write_timeout_us(i2c1, EXT_MAX77958_ADDR, &reg, 1, true, I2C_TIMEOUT);
+    if (write_result != 1) {
+        rp2040_log("EXT_MAX77958_I2C1_TEST: FAIL opcode read pointer write_result=%d\n", write_result);
+        return false;
+    }
+
+    int read_result = i2c_read_timeout_us(i2c1, EXT_MAX77958_ADDR, response, len, false, I2C_TIMEOUT);
+    if (read_result != (int)len) {
+        rp2040_log("EXT_MAX77958_I2C1_TEST: FAIL opcode read_result=%d expected=%u\n",
+                    read_result, (unsigned)len);
+        return false;
+    }
+
+    return true;
+}
+
+static bool external_max77958_i2c1_write_customer_config(void)
+{
+    uint8_t command[33] = {0};
+    max77958_customer_config_t config = {
+        .dbg_src_enable = false,
+        .dbg_snk_enable = false,
+        .audio_acc_enable = false,
+        .trysnk_enable = false,
+        .typec_mode = TYPEC_MODE_SRC,
+        .mem_update_customer = false,
+        .moisture_enable = false
+    };
+
+    command[0] = EXT_MAX77958_OPCODE_WRITE;
+    command[1] = EXT_MAX77958_OPCODE_CUSTOMER_CONFIG_WRITE;
+    command[2] = max77958_build_customer_config_value(&config);
+    command[3] = 0x6A;
+    command[4] = 0x0B;
+    command[5] = 0x60;
+    command[6] = 0x68;
+    command[7] = 0x00;
+    command[8] = 0x64;
+    command[9] = 0x00;
+    command[10] = 0x96;
+    command[11] = 0x00;
+    command[21] = 0x69;
+    command[22] = 0x69;
+    command[23] = 0x35;
+    command[24] = 0x28;
+
+    rp2040_log("EXT_MAX77958_I2C1_TEST: writing source customer config=0x%02x\n", command[2]);
+    return external_max77958_i2c1_opcode_write(command);
+}
+
+static bool external_max77958_i2c1_write_cc_ctrl1_src(void)
+{
+    uint8_t command[33] = {0};
+
+    command[0] = EXT_MAX77958_OPCODE_WRITE;
+    command[1] = EXT_MAX77958_OPCODE_CC_CTRL1_WRITE;
+    command[2] = 0x82;
+
+    rp2040_log("EXT_MAX77958_I2C1_TEST: writing CC_CTRL1=0x82\n");
+    return external_max77958_i2c1_opcode_write(command);
+}
+
+static bool external_max77958_i2c1_read_cc_ctrl1(void)
+{
+    uint8_t command[33] = {0};
+    uint8_t response[33] = {0};
+
+    command[0] = EXT_MAX77958_OPCODE_WRITE;
+    command[1] = EXT_MAX77958_OPCODE_CC_CTRL1_READ;
+    if (!external_max77958_i2c1_opcode_write(command)) {
+        return false;
+    }
+
+    sleep_ms(100);
+    if (!external_max77958_i2c1_opcode_read(response, sizeof response)) {
+        return false;
+    }
+
+    rp2040_log("EXT_MAX77958_I2C1_TEST: CC_CTRL1 response opcode=0x%02x value=0x%02x\n",
+                response[0], response[1]);
+    return response[0] == EXT_MAX77958_OPCODE_CC_CTRL1_READ;
+}
+
+static bool external_max77958_i2c1_set_gpio(bool gpio4, bool gpio5)
+{
+    uint8_t command[33] = {0};
+    uint8_t gpio_val = (gpio5 ? 0x08 : 0x00) | 0x04 | (gpio4 ? 0x02 : 0x00) | 0x01;
+
+    command[0] = EXT_MAX77958_OPCODE_WRITE;
+    command[1] = EXT_MAX77958_OPCODE_GPIO_WRITE;
+    command[2] = 0x00;
+    command[3] = gpio_val;
+
+    rp2040_log("EXT_MAX77958_I2C1_TEST: writing GPIO4=%u GPIO5=%u GPIO53=0x%02x\n",
+                gpio4 ? 1 : 0, gpio5 ? 1 : 0, gpio_val);
+    return external_max77958_i2c1_opcode_write(command);
+}
+
+static void external_max77958_i2c1_log_status(uint32_t elapsed_ms)
+{
+    uint8_t status[8] = {0};
+    uint8_t gpio_command[33] = {0};
+    uint8_t gpio_response[33] = {0};
+
+    if (!external_max77958_i2c1_read_register(0x08, status, sizeof status)) {
+        return;
+    }
+
+    uint8_t cc_status0 = status[4];
+    uint8_t cc_status1 = status[5];
+    uint8_t pd_status0 = status[6];
+    uint8_t pd_status1 = status[7];
+    rp2040_log("EXT_MAX77958_I2C1_TEST t=%lums USBC1=0x%02x SYS=0x%02x BC=0x%02x CC0=0x%02x pin=%u current=%u state=%u CC1=0x%02x wtr=%u detabrt=%u vsafeov=%u PD0=0x%02x PD1=0x%02x power=%u data=%u psrdy=%u\n",
+                (unsigned long)elapsed_ms,
+                status[0], status[1], status[2],
+                cc_status0, (cc_status0 >> 6) & 0x03, (cc_status0 >> 4) & 0x03, cc_status0 & 0x07,
+                cc_status1, (cc_status1 >> 1) & 0x01, (cc_status1 >> 2) & 0x01, (cc_status1 >> 3) & 0x01,
+                pd_status0, pd_status1, (pd_status1 >> 6) & 0x01, (pd_status1 >> 7) & 0x01,
+                (pd_status1 >> 4) & 0x01);
+
+    gpio_command[0] = EXT_MAX77958_OPCODE_WRITE;
+    gpio_command[1] = EXT_MAX77958_OPCODE_GPIO_READ;
+    if (!external_max77958_i2c1_opcode_write(gpio_command)) {
+        return;
+    }
+
+    sleep_ms(20);
+    if (!external_max77958_i2c1_opcode_read(gpio_response, sizeof gpio_response)) {
+        return;
+    }
+
+    rp2040_log("EXT_MAX77958_I2C1_TEST t=%lums GPIO opcode=0x%02x GPIO03=0x%02x GPIO47=0x%02x GPIO8=0x%02x\n",
+                (unsigned long)elapsed_ms, gpio_response[0], gpio_response[1],
+                gpio_response[2], gpio_response[3]);
+}
+#endif
 
 uint8_t* i2c_scan(i2c_inst_t *i2c) {
     uint8_t MAX_DEVICES = 128;

--- a/src/robot.c
+++ b/src/robot.c
@@ -214,6 +214,9 @@ void on_start(){
     sn74ahc125rgyr_init(SN74AHC125RGYR_GPIO1);
     sn74ahc125rgyr_init(SN74AHC125RGYR_GPIO2);
     max77958_init(MAX77958_INTB, &call_queue, &results_queue);
+    #ifdef LOGGER_UART
+    max77958_debug_poll_status(2000, 250);
+    #endif
     #endif
 
     sleep_ms(1000);

--- a/tools/capture_uart_log.py
+++ b/tools/capture_uart_log.py
@@ -12,7 +12,6 @@ import time
 DEFAULT_DEVICE = "/dev/ttyACM0"
 DEFAULT_OUTPUT = "/tmp/max77958-diag.log"
 DIAG_END_MARKERS = (
-    "MAX77958_DIAG: end status poll",
     "EXT_MAX77958_I2C1_TEST: end",
 )
 CC_STATE_NAMES = {
@@ -25,6 +24,15 @@ CC_STATE_NAMES = {
     6: "DISABLED",
     7: "DEBUG_SINK",
 }
+
+LIVE_FILTERS = (
+    "on_start complete",
+    "MAX77958_DIAG:",
+    "CCStat: ccstat changed",
+    "Power source ready",
+    "PD Message:",
+    "opcode_read:",
+)
 
 BAUD_RATES = {
     9600: termios.B9600,
@@ -110,6 +118,214 @@ def capture_uart(fd, output_path, timeout, stop_markers, flash_process):
     return b"".join(chunks).decode("utf-8", "replace"), marker_seen
 
 
+def line_is_relevant(line):
+    return any(token in line for token in LIVE_FILTERS)
+
+
+def parse_role_line(line):
+    state_match = re.search(r"state=(\d+)", line)
+    power_match = re.search(r"pcb_power=([A-Z_]+)", line)
+    data_match = re.search(r"pcb_data=([A-Z_]+)", line)
+    ready_match = re.search(r"pd_ready=(\d+)", line)
+
+    return {
+        "state": int(state_match.group(1)) if state_match else None,
+        "pcb_power": power_match.group(1) if power_match else None,
+        "pcb_data": data_match.group(1) if data_match else None,
+        "pd_ready": int(ready_match.group(1)) if ready_match else None,
+    }
+
+
+def consume_uart_lines(fd, output, deadline, line_callback):
+    chunks = []
+    pending = ""
+
+    while time.monotonic() < deadline:
+        readable, _, _ = select.select([fd], [], [], 0.1)
+        if not readable:
+            continue
+
+        try:
+            chunk = os.read(fd, 4096)
+        except BlockingIOError:
+            chunk = b""
+
+        if not chunk:
+            continue
+
+        output.write(chunk)
+        output.flush()
+        chunks.append(chunk)
+
+        pending += chunk.decode("utf-8", "replace")
+        lines = pending.splitlines(keepends=True)
+        pending = ""
+        if lines and not lines[-1].endswith(("\n", "\r")):
+            pending = lines.pop()
+
+        for raw_line in lines:
+            line = raw_line.strip()
+            if not line:
+                continue
+            if line_is_relevant(line):
+                print(line, flush=True)
+            if line_callback(line):
+                return b"".join(chunks).decode("utf-8", "replace"), True
+
+    return b"".join(chunks).decode("utf-8", "replace"), False
+
+
+def wait_for_startup(fd, output, timeout):
+    print("Waiting for on_start complete before interactive cycles...", flush=True)
+    deadline = time.monotonic() + timeout
+
+    def saw_startup(line):
+        return "on_start complete" in line
+
+    return consume_uart_lines(fd, output, deadline, saw_startup)
+
+
+def wait_for_detach(fd, output, step_timeout):
+    status = {
+        "vbus_off": False,
+        "detached": False,
+        "last_role": None,
+    }
+    deadline = time.monotonic() + step_timeout
+
+    def saw_detach(line):
+        if "MAX77958_DIAG: setting VBUS GPIO4/GPIO5 off" in line:
+            status["vbus_off"] = True
+
+        if " pcb_power=" in line or "state=" in line:
+            role = parse_role_line(line)
+            status["last_role"] = line
+            if role["state"] == 0 or role["pcb_power"] == "UNKNOWN":
+                status["detached"] = True
+
+        return status["detached"] and status["vbus_off"]
+
+    text, ok = consume_uart_lines(fd, output, deadline, saw_detach)
+    return text, ok, status
+
+
+def wait_for_reattach(fd, output, step_timeout):
+    status = {
+        "vbus_on": False,
+        "desired": False,
+        "last_role": None,
+    }
+    deadline = time.monotonic() + step_timeout
+
+    def saw_desired(line):
+        if "MAX77958_DIAG: setting VBUS GPIO4/GPIO5 on" in line:
+            status["vbus_on"] = True
+
+        if " pcb_power=" in line:
+            role = parse_role_line(line)
+            status["last_role"] = line
+            status["desired"] = (
+                role["state"] == 2
+                and role["pcb_power"] == "SOURCE"
+                and role["pcb_data"] == "UFP_DEVICE"
+                and role["pd_ready"] == 1
+            )
+
+        return status["desired"] and status["vbus_on"]
+
+    text, ok = consume_uart_lines(fd, output, deadline, saw_desired)
+    return text, ok, status
+
+
+def desired_baseline_from_text(text):
+    status = {
+        "vbus_on": False,
+        "desired": False,
+        "last_role": None,
+    }
+    lines = text.splitlines()
+    last_on_index = -1
+    last_off_index = -1
+
+    for index, line in enumerate(lines):
+        if "MAX77958_DIAG: setting VBUS GPIO4/GPIO5 on" in line:
+            last_on_index = index
+        if "MAX77958_DIAG: setting VBUS GPIO4/GPIO5 off" in line:
+            last_off_index = index
+        if " pcb_power=" in line:
+            status["last_role"] = line
+            role = parse_role_line(line)
+            status["desired"] = (
+                role["state"] == 2
+                and role["pcb_power"] == "SOURCE"
+                and role["pcb_data"] == "UFP_DEVICE"
+                and role["pd_ready"] == 1
+            )
+
+    status["vbus_on"] = last_on_index > last_off_index
+    return status["desired"] and status["vbus_on"], status
+
+
+def run_interactive_cycles(fd, output_path, timeout, flash_process, cycles, step_timeout):
+    chunks = []
+    marker_seen = False
+
+    with open(output_path, "wb") as output:
+        startup_text, startup_seen = wait_for_startup(fd, output, timeout)
+        chunks.append(startup_text.encode("utf-8", "replace"))
+
+        if not startup_seen:
+            print(f"ERROR: on_start complete was not seen within {timeout:.1f}s", flush=True)
+            text = b"".join(chunks).decode("utf-8", "replace")
+            return text, marker_seen, 1
+
+        baseline_ok, baseline_status = desired_baseline_from_text(startup_text)
+        if not baseline_ok:
+            print(f"Waiting {step_timeout:.1f}s for post-startup attached baseline...", flush=True)
+            baseline_text, baseline_ok, baseline_status = wait_for_reattach(fd, output, step_timeout)
+            chunks.append(baseline_text.encode("utf-8", "replace"))
+
+        if not baseline_ok:
+            print(f"ERROR: startup baseline did not reach SOURCE + UFP + READY + VBUS on within {step_timeout:.1f}s")
+            if baseline_status["last_role"]:
+                print(f"last role line: {baseline_status['last_role']}")
+            print(f"vbus_on_seen: {'yes' if baseline_status['vbus_on'] else 'no'}")
+            text = b"".join(chunks).decode("utf-8", "replace")
+            return text, marker_seen, 1
+
+        print("Startup baseline confirmed: SOURCE + UFP + READY + VBUS on.")
+
+        for cycle in range(1, cycles + 1):
+            input(f"\nCycle {cycle}/{cycles}: press Enter when ready to detach. ")
+            print("Detach the phone now.", flush=True)
+            detach_text, detach_ok, detach_status = wait_for_detach(fd, output, step_timeout)
+            chunks.append(detach_text.encode("utf-8", "replace"))
+            if not detach_ok:
+                print(f"ERROR: cycle {cycle} detach did not reach NO_CONNECTION + VBUS off within {step_timeout:.1f}s")
+                if detach_status["last_role"]:
+                    print(f"last role line: {detach_status['last_role']}")
+                print(f"vbus_off_seen: {'yes' if detach_status['vbus_off'] else 'no'}")
+                text = b"".join(chunks).decode("utf-8", "replace")
+                return text, marker_seen, 1
+            print(f"Cycle {cycle}/{cycles}: detach confirmed.")
+
+            input(f"Cycle {cycle}/{cycles}: press Enter when ready to reattach. ")
+            print("Reattach the phone now.", flush=True)
+            attach_text, attach_ok, attach_status = wait_for_reattach(fd, output, step_timeout)
+            chunks.append(attach_text.encode("utf-8", "replace"))
+            if not attach_ok:
+                print(f"ERROR: cycle {cycle} reattach did not reach SOURCE + UFP + READY + VBUS on within {step_timeout:.1f}s")
+                if attach_status["last_role"]:
+                    print(f"last role line: {attach_status['last_role']}")
+                print(f"vbus_on_seen: {'yes' if attach_status['vbus_on'] else 'no'}")
+                text = b"".join(chunks).decode("utf-8", "replace")
+                return text, marker_seen, 1
+            print(f"Cycle {cycle}/{cycles}: reattach confirmed.")
+
+    text = b"".join(chunks).decode("utf-8", "replace")
+    return text, marker_seen, 0
+
+
 def last_match(lines, pattern):
     regex = re.compile(pattern)
     for line in reversed(lines):
@@ -124,6 +340,11 @@ def parse_last_int(lines, pattern):
     return int(match.group(1)) if match else None
 
 
+def parse_last_str(lines, pattern):
+    _, match = last_match(lines, pattern)
+    return match.group(1) if match else None
+
+
 def summarize(text, output_path, marker_seen, flash_process):
     lines = text.splitlines()
     print(f"\nLog written to: {output_path}")
@@ -134,7 +355,8 @@ def summarize(text, output_path, marker_seen, flash_process):
             status = flash_process.wait()
         print(f"make flash exit code: {status}")
 
-    print(f"diagnostic end marker seen: {'yes' if marker_seen else 'no'}")
+    print(f"stop marker seen: {'yes' if marker_seen else 'no'}")
+    print(f"on_start complete seen: {'yes' if any('on_start complete' in line for line in lines) else 'no'}")
 
     external_lines = [line for line in lines if "EXT_MAX77958_I2C1_TEST" in line]
     if external_lines:
@@ -162,9 +384,21 @@ def summarize(text, output_path, marker_seen, flash_process):
     else:
         print("CC_CTRL1 readback: not found")
 
-    cc0_lines = [line for line in lines if "MAX77958_DIAG" in line and " CC0=" in line]
+    cc0_lines = [line for line in lines if re.search(r"MAX77958_DIAG t=\d+ms CC0=", line)]
     cc1_lines = [line for line in lines if "MAX77958_DIAG" in line and " CC1=" in line]
     pd_lines = [line for line in lines if "MAX77958_DIAG" in line and " PD0=" in line]
+    state_eval_lines = [line for line in lines if "MAX77958_DIAG: state eval" in line]
+    role_lines = [
+        line for line in lines
+        if "MAX77958_DIAG:" in line
+        and " pcb_power=" in line
+        and " pcb_data=" in line
+        and " pd_ready=" in line
+    ]
+    pr_swap_lines = [line for line in lines if "MAX77958_DIAG: requesting PR_SWAP" in line]
+    dr_swap_lines = [line for line in lines if "MAX77958_DIAG: requesting DR_SWAP" in line]
+    vbus_on_lines = [line for line in lines if "MAX77958_DIAG: setting VBUS GPIO4/GPIO5 on" in line]
+    vbus_off_lines = [line for line in lines if "MAX77958_DIAG: setting VBUS GPIO4/GPIO5 off" in line]
     gpio_lines = [line for line in lines if "MAX77958_DIAG" in line and " GPIO53=" in line]
 
     for label, selected in (
@@ -175,8 +409,15 @@ def summarize(text, output_path, marker_seen, flash_process):
     ):
         print(f"{label}: {selected[-1] if selected else 'not found'}")
 
+    print(f"final role line: {role_lines[-1] if role_lines else 'not found'}")
+    print(f"final state eval: {state_eval_lines[-1] if state_eval_lines else 'not found'}")
+    print(f"PR_SWAP requests observed: {len(pr_swap_lines)}")
+    print(f"DR_SWAP requests observed: {len(dr_swap_lines)}")
+    print(f"VBUS on commands observed: {len(vbus_on_lines)}")
+    print(f"VBUS off commands observed: {len(vbus_off_lines)}")
+
     states = []
-    for line in cc0_lines:
+    for line in cc0_lines + role_lines:
         match = re.search(r"state=(\d+)", line)
         if match:
             states.append(int(match.group(1)))
@@ -192,31 +433,44 @@ def summarize(text, output_path, marker_seen, flash_process):
         print("CC states observed: none")
 
     final_state = parse_last_int(cc0_lines, r"state=(\d+)")
+    if final_state is None:
+        final_state = parse_last_int(role_lines, r"state=(\d+)")
     final_data = parse_last_int(pd_lines, r"data=(\d+)")
     final_psrdy = parse_last_int(pd_lines, r"psrdy=(\d+)")
+    if final_data is None:
+        final_data = parse_last_int(state_eval_lines, r"data=(\d+)")
+    if final_psrdy is None:
+        final_psrdy = parse_last_int(state_eval_lines, r"psrdy=(\d+)")
+    final_pcb_power = parse_last_str(role_lines, r"pcb_power=([A-Z_]+)")
+    final_pcb_data = parse_last_str(role_lines, r"pcb_data=([A-Z_]+)")
+    final_pd_ready = parse_last_int(role_lines, r"pd_ready=(\d+)")
     final_gpio_match = last_match(gpio_lines, r"g4=(\d+)/(\d+) g5=(\d+)/(\d+)")[1]
 
-    if final_state is not None or final_data is not None or final_psrdy is not None or final_gpio_match:
+    if final_state is not None or final_data is not None or final_psrdy is not None or final_gpio_match or vbus_on_lines or vbus_off_lines or final_pcb_power:
         source_attached = final_state == 2
-        robot_device = final_data == 0
-        android_host = final_data == 0
-        pd_ready = final_psrdy == 1
-        vbus_enabled = False
+        pcb_source = final_pcb_power == "SOURCE" if final_pcb_power is not None else source_attached
+        pcb_ufp = final_pcb_data == "UFP_DEVICE" if final_pcb_data is not None else final_data == 0
+        pd_ready = final_pd_ready == 1 if final_pd_ready is not None else final_psrdy == 1
+        vbus_enabled = None
         if final_gpio_match:
             g4_dir, g4_out, g5_dir, g5_out = (int(group) for group in final_gpio_match.groups())
             vbus_enabled = g4_dir == 1 and g4_out == 1 and g5_dir == 1 and g5_out == 1
+        elif vbus_on_lines or vbus_off_lines:
+            last_on_index = max((index for index, line in enumerate(lines) if line in vbus_on_lines), default=-1)
+            last_off_index = max((index for index, line in enumerate(lines) if line in vbus_off_lines), default=-1)
+            vbus_enabled = last_on_index > last_off_index
 
         print(
             "final role: "
             f"cc={CC_STATE_NAMES.get(final_state, 'UNKNOWN' if final_state is not None else 'not found')} "
-            f"pd_ready={'yes' if pd_ready else 'no' if final_psrdy is not None else 'not found'} "
-            f"robot_usb={'device/UFP' if robot_device else 'host/DFP' if final_data == 1 else 'not found'} "
-            f"android_usb={'host/DFP' if android_host else 'device/UFP' if final_data == 1 else 'not found'} "
-            f"vbus_enabled={'yes' if vbus_enabled else 'no' if final_gpio_match else 'not found'}"
+            f"pcb_power={final_pcb_power or 'not found'} "
+            f"pcb_data={final_pcb_data or 'not found'} "
+            f"pd_ready={'yes' if pd_ready else 'no' if final_pd_ready is not None or final_psrdy is not None else 'not found'} "
+            f"vbus_enabled={'yes' if vbus_enabled else 'no' if vbus_enabled is not None else 'not found'}"
         )
         print(
             "desired phone-control state: "
-            f"{'yes' if source_attached and pd_ready and robot_device and vbus_enabled else 'no'}"
+            f"{'yes' if pcb_source and pd_ready and pcb_ufp and vbus_enabled else 'no'}"
         )
 
     return 0 if text else 1
@@ -232,6 +486,8 @@ def main():
     parser.add_argument("--output", default=DEFAULT_OUTPUT, help=f"log output path, default {DEFAULT_OUTPUT}")
     parser.add_argument("--flash", action="store_true", help="run make flash after opening UART")
     parser.add_argument("--no-drain", action="store_true", help="do not discard stale bytes before capture")
+    parser.add_argument("--interactive-cycles", type=int, default=0, help="run prompted detach/reattach cycles after on_start complete")
+    parser.add_argument("--step-timeout", type=float, default=5.0, help="seconds to wait for each interactive detach or reattach transition")
     args = parser.parse_args()
 
     try:
@@ -249,17 +505,29 @@ def main():
             drain_serial(fd, 0.25)
 
         flash_process = start_flash(args.flash)
-        text, marker_seen = capture_uart(
-            fd,
-            args.output,
-            args.timeout,
-            DIAG_END_MARKERS,
-            flash_process,
-        )
+        if args.interactive_cycles:
+            text, marker_seen, interactive_status = run_interactive_cycles(
+                fd,
+                args.output,
+                args.timeout,
+                flash_process,
+                args.interactive_cycles,
+                args.step_timeout,
+            )
+        else:
+            interactive_status = 0
+            text, marker_seen = capture_uart(
+                fd,
+                args.output,
+                args.timeout,
+                DIAG_END_MARKERS,
+                flash_process,
+            )
     finally:
         os.close(fd)
 
-    return summarize(text, args.output, marker_seen, flash_process)
+    summary_status = summarize(text, args.output, marker_seen, flash_process)
+    return interactive_status or summary_status
 
 
 if __name__ == "__main__":

--- a/tools/capture_uart_log.py
+++ b/tools/capture_uart_log.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import re
+import select
+import subprocess
+import sys
+import termios
+import time
+
+
+DEFAULT_DEVICE = "/dev/ttyACM0"
+DEFAULT_OUTPUT = "/tmp/max77958-diag.log"
+DIAG_END_MARKER = "MAX77958_DIAG: end status poll"
+
+BAUD_RATES = {
+    9600: termios.B9600,
+    19200: termios.B19200,
+    38400: termios.B38400,
+    57600: termios.B57600,
+    115200: termios.B115200,
+}
+
+
+def configure_serial(fd, baud):
+    try:
+        baud_const = BAUD_RATES[baud]
+    except KeyError:
+        raise ValueError(f"unsupported baud rate: {baud}") from None
+
+    attrs = termios.tcgetattr(fd)
+    attrs[0] = 0
+    attrs[1] = 0
+    attrs[2] = termios.CS8 | termios.CREAD | termios.CLOCAL
+    attrs[3] = 0
+    attrs[4] = baud_const
+    attrs[5] = baud_const
+    attrs[6][termios.VMIN] = 0
+    attrs[6][termios.VTIME] = 0
+    termios.tcsetattr(fd, termios.TCSANOW, attrs)
+    termios.tcflush(fd, termios.TCIOFLUSH)
+
+
+def open_serial(device, baud):
+    fd = os.open(device, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
+    configure_serial(fd, baud)
+    return fd
+
+
+def drain_serial(fd, seconds):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        readable, _, _ = select.select([fd], [], [], 0.05)
+        if not readable:
+            continue
+        try:
+            os.read(fd, 4096)
+        except BlockingIOError:
+            pass
+
+
+def start_flash(enabled):
+    if not enabled:
+        return None
+
+    print("Running make flash while UART capture is active...", flush=True)
+    return subprocess.Popen(["make", "flash"])
+
+
+def capture_uart(fd, output_path, timeout, stop_marker, flash_process):
+    deadline = time.monotonic() + timeout
+    chunks = []
+    marker_seen = False
+
+    with open(output_path, "wb") as output:
+        while time.monotonic() < deadline:
+            readable, _, _ = select.select([fd], [], [], 0.1)
+            if readable:
+                try:
+                    chunk = os.read(fd, 4096)
+                except BlockingIOError:
+                    chunk = b""
+
+                if chunk:
+                    output.write(chunk)
+                    output.flush()
+                    chunks.append(chunk)
+                    text = b"".join(chunks).decode("utf-8", "replace")
+                    if stop_marker in text:
+                        marker_seen = True
+                        break
+
+            if flash_process is not None and flash_process.poll() is not None:
+                if time.monotonic() >= deadline:
+                    break
+
+    return b"".join(chunks).decode("utf-8", "replace"), marker_seen
+
+
+def last_match(lines, pattern):
+    regex = re.compile(pattern)
+    for line in reversed(lines):
+        match = regex.search(line)
+        if match:
+            return line, match
+    return None, None
+
+
+def summarize(text, output_path, marker_seen, flash_process):
+    lines = text.splitlines()
+    print(f"\nLog written to: {output_path}")
+
+    if flash_process is not None:
+        status = flash_process.poll()
+        if status is None:
+            status = flash_process.wait()
+        print(f"make flash exit code: {status}")
+
+    print(f"diagnostic end marker seen: {'yes' if marker_seen else 'no'}")
+
+    _, cc_ctrl = last_match(lines, r"CC_CTRL1 readback = (0x[0-9a-fA-F]+)")
+    if cc_ctrl:
+        print(f"CC_CTRL1 readback: {cc_ctrl.group(1)}")
+    else:
+        print("CC_CTRL1 readback: not found")
+
+    cc0_lines = [line for line in lines if "MAX77958_DIAG" in line and " CC0=" in line]
+    cc1_lines = [line for line in lines if "MAX77958_DIAG" in line and " CC1=" in line]
+    pd_lines = [line for line in lines if "MAX77958_DIAG" in line and " PD0=" in line]
+    gpio_lines = [line for line in lines if "MAX77958_DIAG" in line and " GPIO53=" in line]
+
+    for label, selected in (
+        ("final CC0", cc0_lines),
+        ("final CC1", cc1_lines),
+        ("final PD", pd_lines),
+        ("final GPIO", gpio_lines),
+    ):
+        print(f"{label}: {selected[-1] if selected else 'not found'}")
+
+    states = []
+    for line in cc0_lines:
+        match = re.search(r"state=(\d+)", line)
+        if match:
+            states.append(int(match.group(1)))
+
+    if states:
+        nonzero_states = sorted(set(state for state in states if state != 0))
+        source_seen = 2 in states
+        print(f"CC states observed: {sorted(set(states))}")
+        print(f"source attach observed: {'yes' if source_seen else 'no'}")
+        if nonzero_states and not source_seen:
+            print(f"nonzero CC states observed: {nonzero_states}")
+    else:
+        print("CC states observed: none")
+
+    return 0 if text else 1
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Capture MAX77958 UART diagnostics from the debug probe serial port."
+    )
+    parser.add_argument("--device", default=DEFAULT_DEVICE, help=f"serial device, default {DEFAULT_DEVICE}")
+    parser.add_argument("--baud", type=int, default=115200, help="UART baud rate, default 115200")
+    parser.add_argument("--timeout", type=float, default=30.0, help="capture timeout in seconds, default 30")
+    parser.add_argument("--output", default=DEFAULT_OUTPUT, help=f"log output path, default {DEFAULT_OUTPUT}")
+    parser.add_argument("--flash", action="store_true", help="run make flash after opening UART")
+    parser.add_argument("--no-drain", action="store_true", help="do not discard stale bytes before capture")
+    args = parser.parse_args()
+
+    try:
+        fd = open_serial(args.device, args.baud)
+    except OSError as exc:
+        print(f"ERROR: could not open {args.device}: {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    flash_process = None
+    try:
+        if not args.no_drain:
+            drain_serial(fd, 0.25)
+
+        flash_process = start_flash(args.flash)
+        text, marker_seen = capture_uart(
+            fd,
+            args.output,
+            args.timeout,
+            DIAG_END_MARKER,
+            flash_process,
+        )
+    finally:
+        os.close(fd)
+
+    return summarize(text, args.output, marker_seen, flash_process)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/capture_uart_log.py
+++ b/tools/capture_uart_log.py
@@ -11,7 +11,10 @@ import time
 
 DEFAULT_DEVICE = "/dev/ttyACM0"
 DEFAULT_OUTPUT = "/tmp/max77958-diag.log"
-DIAG_END_MARKER = "MAX77958_DIAG: end status poll"
+DIAG_END_MARKERS = (
+    "MAX77958_DIAG: end status poll",
+    "EXT_MAX77958_I2C1_TEST: end",
+)
 
 BAUD_RATES = {
     9600: termios.B9600,
@@ -67,7 +70,7 @@ def start_flash(enabled):
     return subprocess.Popen(["make", "flash"])
 
 
-def capture_uart(fd, output_path, timeout, stop_marker, flash_process):
+def capture_uart(fd, output_path, timeout, stop_markers, flash_process):
     deadline = time.monotonic() + timeout
     chunks = []
     marker_seen = False
@@ -86,7 +89,7 @@ def capture_uart(fd, output_path, timeout, stop_marker, flash_process):
                     output.flush()
                     chunks.append(chunk)
                     text = b"".join(chunks).decode("utf-8", "replace")
-                    if stop_marker in text:
+                    if any(marker in text for marker in stop_markers):
                         marker_seen = True
                         break
 
@@ -117,6 +120,26 @@ def summarize(text, output_path, marker_seen, flash_process):
         print(f"make flash exit code: {status}")
 
     print(f"diagnostic end marker seen: {'yes' if marker_seen else 'no'}")
+
+    external_lines = [line for line in lines if "EXT_MAX77958_I2C1_TEST" in line]
+    if external_lines:
+        external_status_lines = [line for line in external_lines if " t=" in line and " CC0=" in line]
+        external_gpio_lines = [line for line in external_lines if " t=" in line and " GPIO " in line]
+        external_event_lines = [line for line in external_lines if " t=" not in line]
+        print("external MAX77958 I2C1 test:")
+        for line in external_event_lines:
+            print(f"  {line}")
+        print(f"  final status: {external_status_lines[-1] if external_status_lines else 'not found'}")
+        print(f"  final GPIO: {external_gpio_lines[-1] if external_gpio_lines else 'not found'}")
+
+        external_states = []
+        for line in external_status_lines:
+            match = re.search(r"state=(\d+)", line)
+            if match:
+                external_states.append(int(match.group(1)))
+        if external_states:
+            print(f"  CC states observed: {sorted(set(external_states))}")
+            print(f"  source attach observed: {'yes' if 2 in external_states else 'no'}")
 
     _, cc_ctrl = last_match(lines, r"CC_CTRL1 readback = (0x[0-9a-fA-F]+)")
     if cc_ctrl:
@@ -187,7 +210,7 @@ def main():
             fd,
             args.output,
             args.timeout,
-            DIAG_END_MARKER,
+            DIAG_END_MARKERS,
             flash_process,
         )
     finally:

--- a/tools/capture_uart_log.py
+++ b/tools/capture_uart_log.py
@@ -15,6 +15,16 @@ DIAG_END_MARKERS = (
     "MAX77958_DIAG: end status poll",
     "EXT_MAX77958_I2C1_TEST: end",
 )
+CC_STATE_NAMES = {
+    0: "NO_CONNECTION",
+    1: "SINK_ATTACHED",
+    2: "SOURCE_ATTACHED",
+    3: "AUDIO_ACCESSORY",
+    4: "DEBUG_SOURCE",
+    5: "ERROR",
+    6: "DISABLED",
+    7: "DEBUG_SINK",
+}
 
 BAUD_RATES = {
     9600: termios.B9600,
@@ -109,6 +119,11 @@ def last_match(lines, pattern):
     return None, None
 
 
+def parse_last_int(lines, pattern):
+    _, match = last_match(lines, pattern)
+    return int(match.group(1)) if match else None
+
+
 def summarize(text, output_path, marker_seen, flash_process):
     lines = text.splitlines()
     print(f"\nLog written to: {output_path}")
@@ -175,6 +190,34 @@ def summarize(text, output_path, marker_seen, flash_process):
             print(f"nonzero CC states observed: {nonzero_states}")
     else:
         print("CC states observed: none")
+
+    final_state = parse_last_int(cc0_lines, r"state=(\d+)")
+    final_data = parse_last_int(pd_lines, r"data=(\d+)")
+    final_psrdy = parse_last_int(pd_lines, r"psrdy=(\d+)")
+    final_gpio_match = last_match(gpio_lines, r"g4=(\d+)/(\d+) g5=(\d+)/(\d+)")[1]
+
+    if final_state is not None or final_data is not None or final_psrdy is not None or final_gpio_match:
+        source_attached = final_state == 2
+        robot_device = final_data == 0
+        android_host = final_data == 0
+        pd_ready = final_psrdy == 1
+        vbus_enabled = False
+        if final_gpio_match:
+            g4_dir, g4_out, g5_dir, g5_out = (int(group) for group in final_gpio_match.groups())
+            vbus_enabled = g4_dir == 1 and g4_out == 1 and g5_dir == 1 and g5_out == 1
+
+        print(
+            "final role: "
+            f"cc={CC_STATE_NAMES.get(final_state, 'UNKNOWN' if final_state is not None else 'not found')} "
+            f"pd_ready={'yes' if pd_ready else 'no' if final_psrdy is not None else 'not found'} "
+            f"robot_usb={'device/UFP' if robot_device else 'host/DFP' if final_data == 1 else 'not found'} "
+            f"android_usb={'host/DFP' if android_host else 'device/UFP' if final_data == 1 else 'not found'} "
+            f"vbus_enabled={'yes' if vbus_enabled else 'no' if final_gpio_match else 'not found'}"
+        )
+        print(
+            "desired phone-control state: "
+            f"{'yes' if source_attached and pd_ready and robot_device and vbus_enabled else 'no'}"
+        )
 
     return 0 if text else 1
 


### PR DESCRIPTION
## Summary
- request the phone-power/source role while preserving Android as USB host
- add PR_SWAP/DR_SWAP role handling and swap response configuration
- improve MAX77958 opcode wait and interrupt-drain behavior
- keep role-state diagnostics available for attach/PD debugging

## Notes
This PR is intentionally stacked on `split/max77958-diagnostics` so the production role-control changes can be reviewed separately from the reusable diagnostic tooling.

## Tests
Not run; branch split only.