### PR TITLE
Handle DRV8830 wake UVLO events

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ set(CMAKE_COLOR_MAKEFILE ON)
 # Build options
 option(USE_DOCKER "Build using Docker container" ON)
 option(USE_LOCAL "Build locally instead of Docker" OFF)
+set(DRV8830_SCOPE_TEST "0" CACHE STRING "Enable DRV8830 back/forth scope test")
+set(DRV8830_SCOPE_TEST_CONTROL "0x7A" CACHE STRING "DRV8830 scope test forward control byte")
+set(DRV8830_SCOPE_TEST_DWELL_MS "750" CACHE STRING "DRV8830 scope test motor-on dwell in ms")
+set(DRV8830_SCOPE_TEST_OFF_MS "250" CACHE STRING "DRV8830 scope test motor-off dwell in ms")
+set(DRV8830_SCOPE_TEST_REPEAT "10" CACHE STRING "DRV8830 scope test repeat count")
 
 # Set build type if not specified
 if(NOT CMAKE_BUILD_TYPE)
@@ -84,6 +89,16 @@ pico_enable_stdio_usb(robot 1)
 
 if(LOGGER STREQUAL "UART")
     target_compile_definitions(robot PUBLIC LOGGER_UART=1)
+endif()
+
+if(DRV8830_SCOPE_TEST)
+    target_compile_definitions(robot PUBLIC
+        DRV8830_SCOPE_TEST=1
+        DRV8830_SCOPE_TEST_CONTROL=${DRV8830_SCOPE_TEST_CONTROL}
+        DRV8830_SCOPE_TEST_DWELL_MS=${DRV8830_SCOPE_TEST_DWELL_MS}
+        DRV8830_SCOPE_TEST_OFF_MS=${DRV8830_SCOPE_TEST_OFF_MS}
+        DRV8830_SCOPE_TEST_REPEAT=${DRV8830_SCOPE_TEST_REPEAT}
+    )
 endif()
 
 # Add the standard library to the build

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@ JOBS ?= $(shell nproc)
 DOCKER_DEBUG_CONTAINER := smartphone-robot-debug
 ARCH ?= amd64
 LOGGER ?= USB
+DRV8830_SCOPE_TEST ?= 0
+DRV8830_SCOPE_TEST_CONTROL ?= 0x7A
+DRV8830_SCOPE_TEST_DWELL_MS ?= 750
+DRV8830_SCOPE_TEST_OFF_MS ?= 250
+DRV8830_SCOPE_TEST_REPEAT ?= 10
 
 #  MILESTONE 1: BOARD SELECTION & VALIDATION 
 BOARD ?= customPCB
@@ -20,6 +25,13 @@ ifeq ($(BOARD),pico)
 else
     BOARD_FLAGS = 
 endif
+
+DRV8830_SCOPE_FLAGS = \
+	-DDRV8830_SCOPE_TEST=$(DRV8830_SCOPE_TEST) \
+	-DDRV8830_SCOPE_TEST_CONTROL=$(DRV8830_SCOPE_TEST_CONTROL) \
+	-DDRV8830_SCOPE_TEST_DWELL_MS=$(DRV8830_SCOPE_TEST_DWELL_MS) \
+	-DDRV8830_SCOPE_TEST_OFF_MS=$(DRV8830_SCOPE_TEST_OFF_MS) \
+	-DDRV8830_SCOPE_TEST_REPEAT=$(DRV8830_SCOPE_TEST_REPEAT)
 
 # Variable for the RTT Test to access the serial port
 DOCKER_USB_DEVICE ?= /dev/ttyACM0
@@ -74,13 +86,14 @@ help:
 	@echo "  JOBS=N                - Number of parallel build jobs (default: The number of processor cores)"
 	@echo "  ARCH=amd64|arm64        - Specify architecture for all make targets (default: amd64)"
 	@echo "  LOGGER=USB|UART         - Specify logger interface (default: USB)"
+	@echo "  DRV8830_SCOPE_TEST=0|1 - Enable DRV8830 back/forth scope test (default: 0)"
 	@echo "  Example: make flash DOCKER_USB_DEVICE=/dev/ttyACM0"
 
 # Build firmware
 .PHONY: firmware
 firmware:
 	@echo "Building firmware in Docker with $(JOBS) jobs..."
-	$(DOCKER_RUN) bash -c "rm -rf build && mkdir build && cd build && cmake .. -DLOGGER=$(LOGGER) $(BOARD_FLAGS) && make -j$(JOBS)"
+	$(DOCKER_RUN) bash -c "rm -rf build && mkdir build && cd build && cmake .. -DLOGGER=$(LOGGER) $(BOARD_FLAGS) $(DRV8830_SCOPE_FLAGS) && make -j$(JOBS)"
 
 # Name for the persistent debug container
 DEBUG_CONTAINER := smartphone-robot-debug

--- a/include/drv8830.h
+++ b/include/drv8830.h
@@ -33,5 +33,6 @@ void set_voltage(Motor motor, float voltage);
 void test_drv8830_get_faults();
 void test_drv8830_interrupt();
 uint8_t* drv8830_get_faults();
+void drv8830_scope_test_run();
 
 #endif

--- a/src/drv8830.c
+++ b/src/drv8830.c
@@ -23,6 +23,31 @@ static bool test_drv8830_completed = false;
 const uint32_t drv8830_irq_mask = GPIO_IRQ_EDGE_FALL;
 static void drv8830_clear_faults();
 
+#define DRV8830_FAULT_BIT_FAULT 0
+#define DRV8830_FAULT_BIT_OCP 1
+#define DRV8830_FAULT_BIT_UVLO 2
+#define DRV8830_FAULT_BIT_OTS 3
+#define DRV8830_FAULT_BIT_ILIMIT 4
+
+#ifdef DRV8830_SCOPE_TEST
+#ifndef DRV8830_SCOPE_TEST_CONTROL
+#define DRV8830_SCOPE_TEST_CONTROL 0x7A
+#endif
+#ifndef DRV8830_SCOPE_TEST_DWELL_MS
+#define DRV8830_SCOPE_TEST_DWELL_MS 750
+#endif
+#ifndef DRV8830_SCOPE_TEST_OFF_MS
+#define DRV8830_SCOPE_TEST_OFF_MS 250
+#endif
+#ifndef DRV8830_SCOPE_TEST_REPEAT
+#define DRV8830_SCOPE_TEST_REPEAT 10
+#endif
+
+static int32_t drv8830_scope_set_controls(int32_t packed_controls);
+static void drv8830_log_fault_bits(const char *prefix, const char *motor, uint8_t faults);
+static void drv8830_scope_queue_controls(uint8_t left_control, uint8_t right_control);
+#endif
+
 void drv8830_on_interrupt(uint gpio, uint32_t event_mask){
     //rp2040_log("DRV8830 interrupt\n");
     if (event_mask & drv8830_irq_mask){
@@ -36,16 +61,16 @@ void drv8830_on_interrupt(uint gpio, uint32_t event_mask){
 }
 
 int32_t drv8830_fault_handler(int32_t gpio){
-    uint8_t fault_values = 0; 
+    uint8_t fault_values = 0;
+    uint8_t fault_values_after_clear = 0;
     uint8_t addr = 0;
     uint8_t reg = DRV8830_REG_FAULT;
+    uint8_t clear_buf[2] = {DRV8830_REG_FAULT, (1 << 7)};
     char *motor;
     if (gpio == _gpio_fault1){
-	rp2040_log("Left motor fault\n");
 	addr = MOTOR_LEFT_ADDRESS;
 	motor = "Left";
     }else if (gpio == _gpio_fault2){
-	rp2040_log("Right motor fault\n");
 	addr = MOTOR_RIGHT_ADDRESS;
 	motor = "Right";
     }
@@ -56,7 +81,36 @@ int32_t drv8830_fault_handler(int32_t gpio){
     }else{
         i2c_write_error_handling(i2c, addr, &reg, 1, true);
         i2c_read_error_handling(i2c, addr, &fault_values, 1, false);
+        bool active_fault = (fault_values & (1 << DRV8830_FAULT_BIT_FAULT)) != 0;
+        bool nonfault_status_irq = !active_fault;
+#ifdef DRV8830_SCOPE_TEST
+        uint32_t now_ms = to_ms_since_boot(get_absolute_time());
+        rp2040_log(
+            "DRV8830_SCOPE_TEST fault context t_ms=%" PRIu32 " motor=%s active_fault=%d nonfault_status_irq=%d\n",
+            now_ms,
+            motor,
+            active_fault,
+            nonfault_status_irq);
+        drv8830_log_fault_bits("pre_clear", motor, fault_values);
+#endif
+        if (nonfault_status_irq){
+            i2c_write_error_handling(i2c, addr, clear_buf, 2, false);
+#ifdef DRV8830_SCOPE_TEST
+            i2c_write_error_handling(i2c, addr, &reg, 1, true);
+            i2c_read_error_handling(i2c, addr, &fault_values_after_clear, 1, false);
+            drv8830_log_fault_bits("post_clear", motor, fault_values_after_clear);
+#endif
+            return 0;
+        }
+        rp2040_log("%s motor fault\n", motor);
+#ifdef DRV8830_SCOPE_TEST
+        i2c_write_error_handling(i2c, addr, clear_buf, 2, false);
+        i2c_write_error_handling(i2c, addr, &reg, 1, true);
+        i2c_read_error_handling(i2c, addr, &fault_values_after_clear, 1, false);
+        drv8830_log_fault_bits("post_clear", motor, fault_values_after_clear);
+#else
         rp2040_log("Fault values for Motor %s: 0x%x\n", motor, fault_values);
+#endif
 	return 0;
     }
 }
@@ -89,7 +143,6 @@ void drv8830_init(uint gpio_fault1, uint gpio_fault2) {
  * @param voltage The voltage to set the motor to. This should be between -5.06V and 5.06V.
  */
 void set_motor_control(Motor motor, uint8_t control_value) {
-
     // Determine the appropriate I2C address based on the motor
     uint8_t i2c_address;
     if (motor == MOTOR_LEFT) {
@@ -135,16 +188,7 @@ void set_voltage(Motor motor, float voltage) {
         control_value = 0;
     }
 
-    // Determine the appropriate I2C address based on the motor
-    uint8_t i2c_address;
-    if (motor == MOTOR_LEFT) {
-        i2c_address = MOTOR_LEFT_ADDRESS;
-    } else {
-        i2c_address = MOTOR_RIGHT_ADDRESS;
-    }
-
-    uint8_t buffer[] = { DRV8830_REG_CONTROL, (uint8_t)control_value };
-    i2c_write_blocking(i2c, i2c_address, buffer, sizeof(buffer), false);
+    set_motor_control(motor, (uint8_t)control_value);
 }
 
 uint8_t* drv8830_get_faults(){
@@ -238,3 +282,74 @@ static int32_t drv8830_test_response(){
     return 0;
 }
 
+void drv8830_scope_test_run(){
+#ifdef DRV8830_SCOPE_TEST
+    const uint8_t forward_control = ((uint8_t)DRV8830_SCOPE_TEST_CONTROL & 0xFC) | (1 << DRV8830_IN2_BIT);
+    const uint8_t reverse_control = ((uint8_t)DRV8830_SCOPE_TEST_CONTROL & 0xFC) | (1 << DRV8830_IN1_BIT);
+    const uint8_t off_control = 0;
+
+    rp2040_log("DRV8830_SCOPE_TEST START repeat=%d control=0x%02x forward=0x%02x reverse=0x%02x dwell_ms=%d off_ms=%d\n",
+        DRV8830_SCOPE_TEST_REPEAT,
+        (uint8_t)DRV8830_SCOPE_TEST_CONTROL,
+        forward_control,
+        reverse_control,
+        DRV8830_SCOPE_TEST_DWELL_MS,
+        DRV8830_SCOPE_TEST_OFF_MS);
+
+    drv8830_clear_faults();
+    drv8830_scope_queue_controls(off_control, off_control);
+    sleep_ms(DRV8830_SCOPE_TEST_OFF_MS);
+
+    for (uint32_t i = 0; i < DRV8830_SCOPE_TEST_REPEAT; i++){
+        rp2040_log("DRV8830_SCOPE_TEST phase=%" PRIu32 " direction=forward t_ms=%" PRIu32 "\n", i + 1, to_ms_since_boot(get_absolute_time()));
+        drv8830_scope_queue_controls(forward_control, forward_control);
+        sleep_ms(DRV8830_SCOPE_TEST_DWELL_MS);
+
+        rp2040_log("DRV8830_SCOPE_TEST phase=%" PRIu32 " direction=off_after_forward t_ms=%" PRIu32 "\n", i + 1, to_ms_since_boot(get_absolute_time()));
+        drv8830_scope_queue_controls(off_control, off_control);
+        sleep_ms(DRV8830_SCOPE_TEST_OFF_MS);
+
+        rp2040_log("DRV8830_SCOPE_TEST phase=%" PRIu32 " direction=reverse t_ms=%" PRIu32 "\n", i + 1, to_ms_since_boot(get_absolute_time()));
+        drv8830_scope_queue_controls(reverse_control, reverse_control);
+        sleep_ms(DRV8830_SCOPE_TEST_DWELL_MS);
+
+        rp2040_log("DRV8830_SCOPE_TEST phase=%" PRIu32 " direction=off_after_reverse t_ms=%" PRIu32 "\n", i + 1, to_ms_since_boot(get_absolute_time()));
+        drv8830_scope_queue_controls(off_control, off_control);
+        sleep_ms(DRV8830_SCOPE_TEST_OFF_MS);
+    }
+
+    drv8830_scope_queue_controls(off_control, off_control);
+    sleep_ms(50);
+    rp2040_log("DRV8830_SCOPE_TEST END motors=off t_ms=%" PRIu32 "\n", to_ms_since_boot(get_absolute_time()));
+#endif
+}
+
+#ifdef DRV8830_SCOPE_TEST
+static void drv8830_scope_queue_controls(uint8_t left_control, uint8_t right_control){
+    int32_t packed_controls = ((int32_t)left_control << 8) | right_control;
+    call_queue_try_add(&drv8830_scope_set_controls, packed_controls);
+}
+
+static int32_t drv8830_scope_set_controls(int32_t packed_controls){
+    uint8_t left_control = (uint8_t)((packed_controls >> 8) & 0xFF);
+    uint8_t right_control = (uint8_t)(packed_controls & 0xFF);
+
+    set_motor_control(MOTOR_LEFT, left_control);
+    set_motor_control(MOTOR_RIGHT, right_control);
+    return 0;
+}
+
+static void drv8830_log_fault_bits(const char *prefix, const char *motor, uint8_t faults){
+    rp2040_log(
+        "DRV8830_SCOPE_TEST fault_%s t_ms=%" PRIu32 " motor=%s raw=0x%02x ILIMIT=%d OTS=%d UVLO=%d OCP=%d FAULT=%d\n",
+        prefix,
+        to_ms_since_boot(get_absolute_time()),
+        motor,
+        faults,
+        (faults >> DRV8830_FAULT_BIT_ILIMIT) & 1,
+        (faults >> DRV8830_FAULT_BIT_OTS) & 1,
+        (faults >> DRV8830_FAULT_BIT_UVLO) & 1,
+        (faults >> DRV8830_FAULT_BIT_OCP) & 1,
+        (faults >> DRV8830_FAULT_BIT_FAULT) & 1);
+}
+#endif

--- a/src/robot.c
+++ b/src/robot.c
@@ -265,6 +265,11 @@ void on_start(){
     #endif
 
     rp2040_log("on_start complete\n");
+#ifndef BOARD_PICO
+#ifdef DRV8830_SCOPE_TEST
+    drv8830_scope_test_run();
+#endif
+#endif
     //while(!stdio_usb_connected()){
     //    sleep_ms(100);
     //}

--- a/tools/capture_uart_log.py
+++ b/tools/capture_uart_log.py
@@ -1,0 +1,567 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import re
+import select
+import subprocess
+import sys
+import termios
+import time
+
+
+DEFAULT_DEVICE = "/dev/ttyACM0"
+DEFAULT_OUTPUT = "/tmp/firmware-uart.log"
+DIAG_END_MARKERS = (
+    "EXT_MAX77958_I2C1_TEST: end",
+    "DRV8830_SCOPE_TEST END",
+)
+CC_STATE_NAMES = {
+    0: "NO_CONNECTION",
+    1: "SINK_ATTACHED",
+    2: "SOURCE_ATTACHED",
+    3: "AUDIO_ACCESSORY",
+    4: "DEBUG_SOURCE",
+    5: "ERROR",
+    6: "DISABLED",
+    7: "DEBUG_SINK",
+}
+
+LIVE_FILTERS = (
+    "on_start complete",
+    "DRV8830_SCOPE_TEST",
+    "motor fault",
+    "Fault values",
+    "MAX77958_DIAG:",
+    "CCStat: ccstat changed",
+    "Power source ready",
+    "PD Message:",
+    "opcode_read:",
+)
+
+BAUD_RATES = {
+    9600: termios.B9600,
+    19200: termios.B19200,
+    38400: termios.B38400,
+    57600: termios.B57600,
+    115200: termios.B115200,
+}
+
+
+def configure_serial(fd, baud):
+    try:
+        baud_const = BAUD_RATES[baud]
+    except KeyError:
+        raise ValueError(f"unsupported baud rate: {baud}") from None
+
+    attrs = termios.tcgetattr(fd)
+    attrs[0] = 0
+    attrs[1] = 0
+    attrs[2] = termios.CS8 | termios.CREAD | termios.CLOCAL
+    attrs[3] = 0
+    attrs[4] = baud_const
+    attrs[5] = baud_const
+    attrs[6][termios.VMIN] = 0
+    attrs[6][termios.VTIME] = 0
+    termios.tcsetattr(fd, termios.TCSANOW, attrs)
+    termios.tcflush(fd, termios.TCIOFLUSH)
+
+
+def open_serial(device, baud):
+    fd = os.open(device, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
+    configure_serial(fd, baud)
+    return fd
+
+
+def drain_serial(fd, seconds):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        readable, _, _ = select.select([fd], [], [], 0.05)
+        if not readable:
+            continue
+        try:
+            os.read(fd, 4096)
+        except BlockingIOError:
+            pass
+
+
+def start_flash(enabled):
+    if not enabled:
+        return None
+
+    print("Running make flash while UART capture is active...", flush=True)
+    return subprocess.Popen(["make", "flash"])
+
+
+def capture_uart(fd, output_path, timeout, stop_markers, flash_process):
+    deadline = time.monotonic() + timeout
+    chunks = []
+    marker_seen = False
+
+    with open(output_path, "wb") as output:
+        while time.monotonic() < deadline:
+            readable, _, _ = select.select([fd], [], [], 0.1)
+            if readable:
+                try:
+                    chunk = os.read(fd, 4096)
+                except BlockingIOError:
+                    chunk = b""
+
+                if chunk:
+                    output.write(chunk)
+                    output.flush()
+                    chunks.append(chunk)
+                    text = b"".join(chunks).decode("utf-8", "replace")
+                    if any(marker in text for marker in stop_markers):
+                        marker_seen = True
+                        break
+
+            if flash_process is not None and flash_process.poll() is not None:
+                if time.monotonic() >= deadline:
+                    break
+
+    return b"".join(chunks).decode("utf-8", "replace"), marker_seen
+
+
+def line_is_relevant(line):
+    return any(token in line for token in LIVE_FILTERS)
+
+
+def parse_role_line(line):
+    state_match = re.search(r"state=(\d+)", line)
+    power_match = re.search(r"pcb_power=([A-Z_]+)", line)
+    data_match = re.search(r"pcb_data=([A-Z_]+)", line)
+    ready_match = re.search(r"pd_ready=(\d+)", line)
+
+    return {
+        "state": int(state_match.group(1)) if state_match else None,
+        "pcb_power": power_match.group(1) if power_match else None,
+        "pcb_data": data_match.group(1) if data_match else None,
+        "pd_ready": int(ready_match.group(1)) if ready_match else None,
+    }
+
+
+def consume_uart_lines(fd, output, deadline, line_callback):
+    chunks = []
+    pending = ""
+
+    while time.monotonic() < deadline:
+        readable, _, _ = select.select([fd], [], [], 0.1)
+        if not readable:
+            continue
+
+        try:
+            chunk = os.read(fd, 4096)
+        except BlockingIOError:
+            chunk = b""
+
+        if not chunk:
+            continue
+
+        output.write(chunk)
+        output.flush()
+        chunks.append(chunk)
+
+        pending += chunk.decode("utf-8", "replace")
+        lines = pending.splitlines(keepends=True)
+        pending = ""
+        if lines and not lines[-1].endswith(("\n", "\r")):
+            pending = lines.pop()
+
+        for raw_line in lines:
+            line = raw_line.strip()
+            if not line:
+                continue
+            if line_is_relevant(line):
+                print(line, flush=True)
+            if line_callback(line):
+                return b"".join(chunks).decode("utf-8", "replace"), True
+
+    return b"".join(chunks).decode("utf-8", "replace"), False
+
+
+def wait_for_startup(fd, output, timeout):
+    print("Waiting for on_start complete before interactive cycles...", flush=True)
+    deadline = time.monotonic() + timeout
+
+    def saw_startup(line):
+        return "on_start complete" in line
+
+    return consume_uart_lines(fd, output, deadline, saw_startup)
+
+
+def wait_for_detach(fd, output, step_timeout):
+    status = {
+        "vbus_off": False,
+        "detached": False,
+        "last_role": None,
+    }
+    deadline = time.monotonic() + step_timeout
+
+    def saw_detach(line):
+        if "MAX77958_DIAG: setting VBUS GPIO4/GPIO5 off" in line:
+            status["vbus_off"] = True
+
+        if " pcb_power=" in line or "state=" in line:
+            role = parse_role_line(line)
+            status["last_role"] = line
+            if role["state"] == 0 or role["pcb_power"] == "UNKNOWN":
+                status["detached"] = True
+
+        return status["detached"] and status["vbus_off"]
+
+    text, ok = consume_uart_lines(fd, output, deadline, saw_detach)
+    return text, ok, status
+
+
+def wait_for_reattach(fd, output, step_timeout):
+    status = {
+        "vbus_on": False,
+        "desired": False,
+        "last_role": None,
+    }
+    deadline = time.monotonic() + step_timeout
+
+    def saw_desired(line):
+        if "MAX77958_DIAG: setting VBUS GPIO4/GPIO5 on" in line:
+            status["vbus_on"] = True
+
+        if " pcb_power=" in line:
+            role = parse_role_line(line)
+            status["last_role"] = line
+            status["desired"] = (
+                role["state"] == 2
+                and role["pcb_power"] == "SOURCE"
+                and role["pcb_data"] == "UFP_DEVICE"
+                and role["pd_ready"] == 1
+            )
+
+        return status["desired"] and status["vbus_on"]
+
+    text, ok = consume_uart_lines(fd, output, deadline, saw_desired)
+    return text, ok, status
+
+
+def desired_baseline_from_text(text):
+    status = {
+        "vbus_on": False,
+        "desired": False,
+        "last_role": None,
+    }
+    lines = text.splitlines()
+    last_on_index = -1
+    last_off_index = -1
+
+    for index, line in enumerate(lines):
+        if "MAX77958_DIAG: setting VBUS GPIO4/GPIO5 on" in line:
+            last_on_index = index
+        if "MAX77958_DIAG: setting VBUS GPIO4/GPIO5 off" in line:
+            last_off_index = index
+        if " pcb_power=" in line:
+            status["last_role"] = line
+            role = parse_role_line(line)
+            status["desired"] = (
+                role["state"] == 2
+                and role["pcb_power"] == "SOURCE"
+                and role["pcb_data"] == "UFP_DEVICE"
+                and role["pd_ready"] == 1
+            )
+
+    status["vbus_on"] = last_on_index > last_off_index
+    return status["desired"] and status["vbus_on"], status
+
+
+def run_interactive_cycles(fd, output_path, timeout, flash_process, cycles, step_timeout):
+    chunks = []
+    marker_seen = False
+
+    with open(output_path, "wb") as output:
+        startup_text, startup_seen = wait_for_startup(fd, output, timeout)
+        chunks.append(startup_text.encode("utf-8", "replace"))
+
+        if not startup_seen:
+            print(f"ERROR: on_start complete was not seen within {timeout:.1f}s", flush=True)
+            text = b"".join(chunks).decode("utf-8", "replace")
+            return text, marker_seen, 1
+
+        baseline_ok, baseline_status = desired_baseline_from_text(startup_text)
+        if not baseline_ok:
+            print(f"Waiting {step_timeout:.1f}s for post-startup attached baseline...", flush=True)
+            baseline_text, baseline_ok, baseline_status = wait_for_reattach(fd, output, step_timeout)
+            chunks.append(baseline_text.encode("utf-8", "replace"))
+
+        if not baseline_ok:
+            print(f"ERROR: startup baseline did not reach SOURCE + UFP + READY + VBUS on within {step_timeout:.1f}s")
+            if baseline_status["last_role"]:
+                print(f"last role line: {baseline_status['last_role']}")
+            print(f"vbus_on_seen: {'yes' if baseline_status['vbus_on'] else 'no'}")
+            text = b"".join(chunks).decode("utf-8", "replace")
+            return text, marker_seen, 1
+
+        print("Startup baseline confirmed: SOURCE + UFP + READY + VBUS on.")
+
+        for cycle in range(1, cycles + 1):
+            input(f"\nCycle {cycle}/{cycles}: press Enter when ready to detach. ")
+            print("Detach the phone now.", flush=True)
+            detach_text, detach_ok, detach_status = wait_for_detach(fd, output, step_timeout)
+            chunks.append(detach_text.encode("utf-8", "replace"))
+            if not detach_ok:
+                print(f"ERROR: cycle {cycle} detach did not reach NO_CONNECTION + VBUS off within {step_timeout:.1f}s")
+                if detach_status["last_role"]:
+                    print(f"last role line: {detach_status['last_role']}")
+                print(f"vbus_off_seen: {'yes' if detach_status['vbus_off'] else 'no'}")
+                text = b"".join(chunks).decode("utf-8", "replace")
+                return text, marker_seen, 1
+            print(f"Cycle {cycle}/{cycles}: detach confirmed.")
+
+            input(f"Cycle {cycle}/{cycles}: press Enter when ready to reattach. ")
+            print("Reattach the phone now.", flush=True)
+            attach_text, attach_ok, attach_status = wait_for_reattach(fd, output, step_timeout)
+            chunks.append(attach_text.encode("utf-8", "replace"))
+            if not attach_ok:
+                print(f"ERROR: cycle {cycle} reattach did not reach SOURCE + UFP + READY + VBUS on within {step_timeout:.1f}s")
+                if attach_status["last_role"]:
+                    print(f"last role line: {attach_status['last_role']}")
+                print(f"vbus_on_seen: {'yes' if attach_status['vbus_on'] else 'no'}")
+                text = b"".join(chunks).decode("utf-8", "replace")
+                return text, marker_seen, 1
+            print(f"Cycle {cycle}/{cycles}: reattach confirmed.")
+
+    text = b"".join(chunks).decode("utf-8", "replace")
+    return text, marker_seen, 0
+
+
+def last_match(lines, pattern):
+    regex = re.compile(pattern)
+    for line in reversed(lines):
+        match = regex.search(line)
+        if match:
+            return line, match
+    return None, None
+
+
+def parse_last_int(lines, pattern):
+    _, match = last_match(lines, pattern)
+    return int(match.group(1)) if match else None
+
+
+def parse_last_str(lines, pattern):
+    _, match = last_match(lines, pattern)
+    return match.group(1) if match else None
+
+
+def summarize(text, output_path, marker_seen, flash_process):
+    lines = text.splitlines()
+    print(f"\nLog written to: {output_path}")
+
+    if flash_process is not None:
+        status = flash_process.poll()
+        if status is None:
+            status = flash_process.wait()
+        print(f"make flash exit code: {status}")
+
+    print(f"capture completion marker seen: {'yes' if marker_seen else 'no'}")
+    print(f"on_start complete seen: {'yes' if any('on_start complete' in line for line in lines) else 'no'}")
+
+    drv8830_scope_lines = [line for line in lines if "DRV8830_SCOPE_TEST" in line]
+    if drv8830_scope_lines:
+        drv8830_pre_clear_lines = [line for line in drv8830_scope_lines if "fault_pre_clear" in line]
+        drv8830_post_clear_lines = [line for line in drv8830_scope_lines if "fault_post_clear" in line]
+        drv8830_nonfault_status_lines = [line for line in drv8830_scope_lines if "nonfault_status_irq=1" in line]
+        drv8830_active_fault_lines = [line for line in drv8830_scope_lines if "active_fault=1" in line]
+        drv8830_uvlo_only_lines = [
+            line for line in drv8830_pre_clear_lines
+            if "UVLO=1" in line and "FAULT=0" in line
+        ]
+        drv8830_real_uvlo_lines = [
+            line for line in drv8830_pre_clear_lines
+            if "UVLO=1" in line and "FAULT=1" in line
+        ]
+        drv8830_motor_fault_lines = [
+            line for line in lines
+            if "Left motor fault" in line or "Right motor fault" in line
+        ]
+
+        print("DRV8830 scope test:")
+        print(f"  lines observed: {len(drv8830_scope_lines)}")
+        print(f"  non-fault status IRQs: {len(drv8830_nonfault_status_lines)}")
+        print(f"  active fault IRQs: {len(drv8830_active_fault_lines)}")
+        print(f"  UVLO-only pre-clear reads: {len(drv8830_uvlo_only_lines)}")
+        print(f"  true UVLO pre-clear reads: {len(drv8830_real_uvlo_lines)}")
+        print(f"  generic motor fault logs: {len(drv8830_motor_fault_lines)}")
+        print(f"  final pre-clear: {drv8830_pre_clear_lines[-1] if drv8830_pre_clear_lines else 'not found'}")
+        print(f"  final post-clear: {drv8830_post_clear_lines[-1] if drv8830_post_clear_lines else 'not found'}")
+
+    external_lines = [line for line in lines if "EXT_MAX77958_I2C1_TEST" in line]
+    if external_lines:
+        external_status_lines = [line for line in external_lines if " t=" in line and " CC0=" in line]
+        external_gpio_lines = [line for line in external_lines if " t=" in line and " GPIO " in line]
+        external_event_lines = [line for line in external_lines if " t=" not in line]
+        print("external MAX77958 I2C1 test:")
+        for line in external_event_lines:
+            print(f"  {line}")
+        print(f"  final status: {external_status_lines[-1] if external_status_lines else 'not found'}")
+        print(f"  final GPIO: {external_gpio_lines[-1] if external_gpio_lines else 'not found'}")
+
+        external_states = []
+        for line in external_status_lines:
+            match = re.search(r"state=(\d+)", line)
+            if match:
+                external_states.append(int(match.group(1)))
+        if external_states:
+            print(f"  CC states observed: {sorted(set(external_states))}")
+            print(f"  source attach observed: {'yes' if 2 in external_states else 'no'}")
+
+    _, cc_ctrl = last_match(lines, r"CC_CTRL1 readback = (0x[0-9a-fA-F]+)")
+    if cc_ctrl:
+        print(f"CC_CTRL1 readback: {cc_ctrl.group(1)}")
+    else:
+        print("CC_CTRL1 readback: not found")
+
+    cc0_lines = [line for line in lines if re.search(r"MAX77958_DIAG t=\d+ms CC0=", line)]
+    cc1_lines = [line for line in lines if "MAX77958_DIAG" in line and " CC1=" in line]
+    pd_lines = [line for line in lines if "MAX77958_DIAG" in line and " PD0=" in line]
+    state_eval_lines = [line for line in lines if "MAX77958_DIAG: state eval" in line]
+    role_lines = [
+        line for line in lines
+        if "MAX77958_DIAG:" in line
+        and " pcb_power=" in line
+        and " pcb_data=" in line
+        and " pd_ready=" in line
+    ]
+    pr_swap_lines = [line for line in lines if "MAX77958_DIAG: requesting PR_SWAP" in line]
+    dr_swap_lines = [line for line in lines if "MAX77958_DIAG: requesting DR_SWAP" in line]
+    vbus_on_lines = [line for line in lines if "MAX77958_DIAG: setting VBUS GPIO4/GPIO5 on" in line]
+    vbus_off_lines = [line for line in lines if "MAX77958_DIAG: setting VBUS GPIO4/GPIO5 off" in line]
+    gpio_lines = [line for line in lines if "MAX77958_DIAG" in line and " GPIO53=" in line]
+
+    for label, selected in (
+        ("final CC0", cc0_lines),
+        ("final CC1", cc1_lines),
+        ("final PD", pd_lines),
+        ("final GPIO", gpio_lines),
+    ):
+        print(f"{label}: {selected[-1] if selected else 'not found'}")
+
+    print(f"final role line: {role_lines[-1] if role_lines else 'not found'}")
+    print(f"final state eval: {state_eval_lines[-1] if state_eval_lines else 'not found'}")
+    print(f"PR_SWAP requests observed: {len(pr_swap_lines)}")
+    print(f"DR_SWAP requests observed: {len(dr_swap_lines)}")
+    print(f"VBUS on commands observed: {len(vbus_on_lines)}")
+    print(f"VBUS off commands observed: {len(vbus_off_lines)}")
+
+    states = []
+    for line in cc0_lines + role_lines:
+        match = re.search(r"state=(\d+)", line)
+        if match:
+            states.append(int(match.group(1)))
+
+    if states:
+        nonzero_states = sorted(set(state for state in states if state != 0))
+        source_seen = 2 in states
+        print(f"CC states observed: {sorted(set(states))}")
+        print(f"source attach observed: {'yes' if source_seen else 'no'}")
+        if nonzero_states and not source_seen:
+            print(f"nonzero CC states observed: {nonzero_states}")
+    else:
+        print("CC states observed: none")
+
+    final_state = parse_last_int(cc0_lines, r"state=(\d+)")
+    if final_state is None:
+        final_state = parse_last_int(role_lines, r"state=(\d+)")
+    final_data = parse_last_int(pd_lines, r"data=(\d+)")
+    final_psrdy = parse_last_int(pd_lines, r"psrdy=(\d+)")
+    if final_data is None:
+        final_data = parse_last_int(state_eval_lines, r"data=(\d+)")
+    if final_psrdy is None:
+        final_psrdy = parse_last_int(state_eval_lines, r"psrdy=(\d+)")
+    final_pcb_power = parse_last_str(role_lines, r"pcb_power=([A-Z_]+)")
+    final_pcb_data = parse_last_str(role_lines, r"pcb_data=([A-Z_]+)")
+    final_pd_ready = parse_last_int(role_lines, r"pd_ready=(\d+)")
+    final_gpio_match = last_match(gpio_lines, r"g4=(\d+)/(\d+) g5=(\d+)/(\d+)")[1]
+
+    if final_state is not None or final_data is not None or final_psrdy is not None or final_gpio_match or vbus_on_lines or vbus_off_lines or final_pcb_power:
+        source_attached = final_state == 2
+        pcb_source = final_pcb_power == "SOURCE" if final_pcb_power is not None else source_attached
+        pcb_ufp = final_pcb_data == "UFP_DEVICE" if final_pcb_data is not None else final_data == 0
+        pd_ready = final_pd_ready == 1 if final_pd_ready is not None else final_psrdy == 1
+        vbus_enabled = None
+        if final_gpio_match:
+            g4_dir, g4_out, g5_dir, g5_out = (int(group) for group in final_gpio_match.groups())
+            vbus_enabled = g4_dir == 1 and g4_out == 1 and g5_dir == 1 and g5_out == 1
+        elif vbus_on_lines or vbus_off_lines:
+            last_on_index = max((index for index, line in enumerate(lines) if line in vbus_on_lines), default=-1)
+            last_off_index = max((index for index, line in enumerate(lines) if line in vbus_off_lines), default=-1)
+            vbus_enabled = last_on_index > last_off_index
+
+        print(
+            "final role: "
+            f"cc={CC_STATE_NAMES.get(final_state, 'UNKNOWN' if final_state is not None else 'not found')} "
+            f"pcb_power={final_pcb_power or 'not found'} "
+            f"pcb_data={final_pcb_data or 'not found'} "
+            f"pd_ready={'yes' if pd_ready else 'no' if final_pd_ready is not None or final_psrdy is not None else 'not found'} "
+            f"vbus_enabled={'yes' if vbus_enabled else 'no' if vbus_enabled is not None else 'not found'}"
+        )
+        print(
+            "desired phone-control state: "
+            f"{'yes' if pcb_source and pd_ready and pcb_ufp and vbus_enabled else 'no'}"
+        )
+
+    return 0 if text else 1
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Capture firmware UART diagnostics from the debug probe serial port."
+    )
+    parser.add_argument("--device", default=DEFAULT_DEVICE, help=f"serial device, default {DEFAULT_DEVICE}")
+    parser.add_argument("--baud", type=int, default=115200, help="UART baud rate, default 115200")
+    parser.add_argument("--timeout", type=float, default=30.0, help="capture timeout in seconds, default 30")
+    parser.add_argument("--output", default=DEFAULT_OUTPUT, help=f"log output path, default {DEFAULT_OUTPUT}")
+    parser.add_argument("--flash", action="store_true", help="run make flash after opening UART")
+    parser.add_argument("--no-drain", action="store_true", help="do not discard stale bytes before capture")
+    parser.add_argument("--interactive-cycles", type=int, default=0, help="run prompted detach/reattach cycles after on_start complete")
+    parser.add_argument("--step-timeout", type=float, default=5.0, help="seconds to wait for each interactive detach or reattach transition")
+    args = parser.parse_args()
+
+    try:
+        fd = open_serial(args.device, args.baud)
+    except OSError as exc:
+        print(f"ERROR: could not open {args.device}: {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    flash_process = None
+    try:
+        if not args.no_drain:
+            drain_serial(fd, 0.25)
+
+        flash_process = start_flash(args.flash)
+        if args.interactive_cycles:
+            text, marker_seen, interactive_status = run_interactive_cycles(
+                fd,
+                args.output,
+                args.timeout,
+                flash_process,
+                args.interactive_cycles,
+                args.step_timeout,
+            )
+        else:
+            interactive_status = 0
+            text, marker_seen = capture_uart(
+                fd,
+                args.output,
+                args.timeout,
+                DIAG_END_MARKERS,
+                flash_process,
+            )
+    finally:
+        os.close(fd)
+
+    summary_status = summarize(text, args.output, marker_seen, flash_process)
+    return interactive_status or summary_status
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/capture_uart_log.py
+++ b/tools/capture_uart_log.py
@@ -95,6 +95,7 @@ def start_flash(enabled):
 def capture_uart(fd, output_path, timeout, stop_markers, flash_process):
     deadline = time.monotonic() + timeout
     chunks = []
+    pending = ""
     marker_seen = False
 
     with open(output_path, "wb") as output:
@@ -110,6 +111,17 @@ def capture_uart(fd, output_path, timeout, stop_markers, flash_process):
                     output.write(chunk)
                     output.flush()
                     chunks.append(chunk)
+                    pending += chunk.decode("utf-8", "replace")
+                    lines = pending.splitlines(keepends=True)
+                    pending = ""
+                    if lines and not lines[-1].endswith(("\n", "\r")):
+                        pending = lines.pop()
+
+                    for raw_line in lines:
+                        line = raw_line.strip()
+                        if line and line_is_relevant(line):
+                            print(line, flush=True)
+
                     text = b"".join(chunks).decode("utf-8", "replace")
                     if any(marker in text for marker in stop_markers):
                         marker_seen = True


### PR DESCRIPTION
## Summary
- add a firmware-only DRV8830 scope test for motor direction transitions
- restore the scope test to the slow off-dwell pattern that reproduces the FAULTn wake behavior
- handle TI-confirmed DRV8830 sleep-exit FAULTn pulses by using the fault register `FAULT` bit as the real-fault discriminator
- extend the UART capture helper so DRV8830 scope-test evidence is included in saved-log summaries
- allow UART capture to complete on the `DRV8830_SCOPE_TEST END` marker instead of relying only on timeout

## Related
- Hardware investigation: tekkura/sr-cad#4

## TI guidance and firmware policy
TI confirmed that `UVLO=1, FAULT=0` after sleep exit is expected and benign. When the DRV8830 exits low-power shutdown (`IN1=IN2=0` to either input high), the UVLO comparator can deglitch during internal power-up and pulse `FAULTn` low without setting the main `FAULT` bit.

The DRV8830 datasheet defines `FAULT` bit `D0` as the aggregate fault discriminator. Firmware behavior in this PR follows that policy:
- if register `0x01` has `FAULT` bit `D0 = 0`, treat the interrupt as a non-fault status interrupt, clear/discard it, and do not log a motor fault in production
- if `FAULT=1`, treat it as a real motor fault; `UVLO=1` in that state indicates true undervoltage and the real fault path remains active
- in `DRV8830_SCOPE_TEST` builds, raw pre-clear/post-clear status bits remain logged so unexpected non-fault status combinations are visible during diagnostics

## UART capture script provenance
- `tools/capture_uart_log.py` was brought over from `split/max77958-role-control`, where it was added/updated by `60eeda9 Stabilize MAX77958 role handling diagnostics`.
- This PR intentionally reuses the same capture helper instead of introducing a second UART logging script, so later merges with the MAX77958 role-control work should resolve as the same file rather than a duplicate tool.
- The helper now includes DRV8830 scope-test lines in the saved-log summary and recognizes the DRV8830 scope-test end marker.

## Verification
- `make firmware LOGGER=UART DRV8830_SCOPE_TEST=1`
- `make firmware LOGGER=UART BOARD=pico DRV8830_SCOPE_TEST=1`
- `make firmware LOGGER=UART`
- `python3 -m py_compile tools/capture_uart_log.py`
- Hardware UART capture: `/tmp/drv8830-ti-wake-test.log`
  - observed repeated `raw=0x04` / `UVLO=1` / `FAULT=0` events after off-to-drive transitions
  - observed `active_fault=0` / `nonfault_status_irq=1`
  - observed those events cleared to `raw=0x00`
  - observed no generic motor fault logs for those interrupts
