### PR TITLE
Fix BQ27742 temperature reporting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CMAKE_COLOR_MAKEFILE ON)
 # Build options
 option(USE_DOCKER "Build using Docker container" ON)
 option(USE_LOCAL "Build locally instead of Docker" OFF)
+set(BQ27742_TEMP_TEST "0" CACHE STRING "Enable BQ27742 temperature diagnostic logs")
 
 # Set build type if not specified
 if(NOT CMAKE_BUILD_TYPE)
@@ -84,6 +85,10 @@ pico_enable_stdio_usb(robot 1)
 
 if(LOGGER STREQUAL "UART")
     target_compile_definitions(robot PUBLIC LOGGER_UART=1)
+endif()
+
+if(BQ27742_TEMP_TEST)
+    target_compile_definitions(robot PUBLIC BQ27742_TEMP_TEST=1)
 endif()
 
 # Add the standard library to the build

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ JOBS ?= $(shell nproc)
 DOCKER_DEBUG_CONTAINER := smartphone-robot-debug
 ARCH ?= amd64
 LOGGER ?= USB
+BQ27742_TEMP_TEST ?= 0
 
 #  MILESTONE 1: BOARD SELECTION & VALIDATION 
 BOARD ?= customPCB
@@ -20,6 +21,9 @@ ifeq ($(BOARD),pico)
 else
     BOARD_FLAGS = 
 endif
+
+BQ27742_TEMP_FLAGS = \
+	-DBQ27742_TEMP_TEST=$(BQ27742_TEMP_TEST)
 
 # Variable for the RTT Test to access the serial port
 DOCKER_USB_DEVICE ?= /dev/ttyACM0
@@ -63,6 +67,7 @@ help:
 	@echo "  make docker      - Build or rebuild the Docker image (must be in project root)"
 	@echo "  make shell       - Start an interactive shell in the Docker container"
 	@echo "  make benchmark   - Build and run host benchmark (in Docker)"
+	@echo "  make bq27742-temp-test-firmware - Build BQ27742 temperature diagnostic firmware"
 	@echo "  make test TEST=rtt BOARD=[pico|customPCB] - Run full RTT benchmark flow"
 	@echo ""
 	@echo "Assumptions:"
@@ -74,13 +79,18 @@ help:
 	@echo "  JOBS=N                - Number of parallel build jobs (default: The number of processor cores)"
 	@echo "  ARCH=amd64|arm64        - Specify architecture for all make targets (default: amd64)"
 	@echo "  LOGGER=USB|UART         - Specify logger interface (default: USB)"
+	@echo "  BQ27742_TEMP_TEST=0|1 - Enable BQ27742 temperature diagnostic logs (default: 0)"
 	@echo "  Example: make flash DOCKER_USB_DEVICE=/dev/ttyACM0"
 
 # Build firmware
 .PHONY: firmware
 firmware:
 	@echo "Building firmware in Docker with $(JOBS) jobs..."
-	$(DOCKER_RUN) bash -c "rm -rf build && mkdir build && cd build && cmake .. -DLOGGER=$(LOGGER) $(BOARD_FLAGS) && make -j$(JOBS)"
+	$(DOCKER_RUN) bash -c "rm -rf build && mkdir build && cd build && cmake .. -DLOGGER=$(LOGGER) $(BOARD_FLAGS) $(BQ27742_TEMP_FLAGS) && make -j$(JOBS)"
+
+.PHONY: bq27742-temp-test-firmware
+bq27742-temp-test-firmware:
+	$(MAKE) firmware BQ27742_TEMP_TEST=1 LOGGER=UART
 
 # Name for the persistent debug container
 DEBUG_CONTAINER := smartphone-robot-debug

--- a/include/bq27742_g1.h
+++ b/include/bq27742_g1.h
@@ -45,5 +45,8 @@ uint8_t bq27742_g1_get_soh();
 uint16_t bq27742_g1_get_flags();
 void bq27742_g1_shutdown();
 void bq27742_g1_fw_version_check();
+#ifdef BQ27742_TEMP_TEST
+void bq27742_g1_temp_test_run();
+#endif
 
 #endif

--- a/src/bq27742_g1.c
+++ b/src/bq27742_g1.c
@@ -14,6 +14,24 @@ static uint16_t temperature = 0;
 static uint32_t soh = 0;
 static void bq27742_g1_clear_shutdown();
 
+#ifdef BQ27742_TEMP_TEST
+static uint16_t bq27742_g1_read_word(uint8_t command, uint8_t *low_byte, uint8_t *high_byte){
+    memset(send_buf, 0, sizeof send_buf);
+    memset(return_buf, 0, sizeof return_buf);
+    send_buf[0] = command;
+    i2c_write_error_handling(i2c0, BQ27742_G1_ADDR, send_buf, 1, true);
+    i2c_read_error_handling(i2c0, BQ27742_G1_ADDR, return_buf, 2, false);
+
+    *low_byte = return_buf[0];
+    *high_byte = return_buf[1];
+    return (return_buf[1] << 8) | return_buf[0];
+}
+
+static int16_t bq27742_g1_kelvin10_to_celsius10(uint16_t raw_kelvin10){
+    return (int16_t)raw_kelvin10 - 2732;
+}
+#endif
+
 uint16_t bq27742_g1_get_voltage(){
     memset(return_buf, 0, sizeof return_buf);
     memset(&voltage, 0, sizeof(voltage));
@@ -86,7 +104,7 @@ uint16_t bq27742_g1_get_temp(){
     float temperature_ = (float)((return_buf[1] << 8) | return_buf[0]);
     temperature_ = (temperature_ - 2731.5);
     temperature_ = temperature_ / 10.0;
-    temperature = (uint16_t)temperature;
+    temperature = (uint16_t)temperature_;
     rp2040_log("Temperature: %d\n", (int)temperature);
     return temperature; 
 }
@@ -222,6 +240,51 @@ void bq27742_g1_fw_version_check(){
     bq27742_g1_control(0x0002); // Read FW Version
     rp2040_log("FW Version: 0x%02x%02x\n", return_buf[1], return_buf[0]);
 }
+
+#ifdef BQ27742_TEMP_TEST
+void bq27742_g1_temp_test_run(){
+    uint8_t selected_low = 0;
+    uint8_t selected_high = 0;
+    uint8_t internal_low = 0;
+    uint8_t internal_high = 0;
+
+    rp2040_log("BQ27742_TEMP_TEST START\n");
+
+    uint16_t selected_raw = bq27742_g1_read_word(0x06, &selected_low, &selected_high);
+    int16_t selected_c_x10 = bq27742_g1_kelvin10_to_celsius10(selected_raw);
+    rp2040_log(
+        "BQ27742_TEMP_TEST selected_temp raw=0x%04x lsb=0x%02x msb=0x%02x c_x10=%d\n",
+        selected_raw,
+        selected_low,
+        selected_high,
+        selected_c_x10
+    );
+
+    uint16_t internal_raw = bq27742_g1_read_word(0x28, &internal_low, &internal_high);
+    int16_t internal_c_x10 = bq27742_g1_kelvin10_to_celsius10(internal_raw);
+    rp2040_log(
+        "BQ27742_TEMP_TEST internal_temp raw=0x%04x lsb=0x%02x msb=0x%02x c_x10=%d\n",
+        internal_raw,
+        internal_low,
+        internal_high,
+        internal_c_x10
+    );
+
+    uint16_t voltage_mv = bq27742_g1_get_voltage();
+    uint8_t safety_status = bq27742_g1_get_safety_stats();
+    uint16_t flags = bq27742_g1_get_flags();
+    uint16_t api_temp_c = bq27742_g1_get_temp();
+    rp2040_log(
+        "BQ27742_TEMP_TEST api_temp_c=%u voltage_mv=%u safety=0x%02x flags=0x%04x\n",
+        api_temp_c,
+        voltage_mv,
+        safety_status,
+        flags
+    );
+
+    rp2040_log("BQ27742_TEMP_TEST END\n");
+}
+#endif
 
 void bq27742_g1_shutdown(){
     bq27742_g1_set_shutdown();

--- a/src/robot.c
+++ b/src/robot.c
@@ -222,6 +222,9 @@ void on_start(){
     #ifndef BOARD_PICO
     bq27742_g1_init();
     bq27742_g1_fw_version_check();
+    #ifdef BQ27742_TEMP_TEST
+    bq27742_g1_temp_test_run();
+    #endif
     // Be sure to do this last
     sn74ahc125rgyr_on_end_of_start(SN74AHC125RGYR_GPIO1);
     sn74ahc125rgyr_on_end_of_start(SN74AHC125RGYR_GPIO2);

--- a/tools/bq27742_temp_test.py
+++ b/tools/bq27742_temp_test.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import re
+import select
+import subprocess
+import sys
+import termios
+import time
+
+
+DEFAULT_DEVICE = "/dev/ttyACM0"
+DEFAULT_OUTPUT = "/tmp/bq27742-temp-test.log"
+DEFAULT_BAUD = 115200
+
+BAUD_RATES = {
+    9600: termios.B9600,
+    19200: termios.B19200,
+    38400: termios.B38400,
+    57600: termios.B57600,
+    115200: termios.B115200,
+}
+
+TEMP_RE = re.compile(
+    r"BQ27742_TEMP_TEST (?P<name>selected_temp|internal_temp) "
+    r"raw=0x(?P<raw>[0-9a-fA-F]{4}) "
+    r"lsb=0x(?P<lsb>[0-9a-fA-F]{2}) "
+    r"msb=0x(?P<msb>[0-9a-fA-F]{2}) "
+    r"c_x10=(?P<c_x10>-?\d+)"
+)
+API_RE = re.compile(
+    r"BQ27742_TEMP_TEST api_temp_c=(?P<api>\d+) "
+    r"voltage_mv=(?P<voltage>\d+) "
+    r"safety=0x(?P<safety>[0-9a-fA-F]{2}) "
+    r"flags=0x(?P<flags>[0-9a-fA-F]{4})"
+)
+
+
+def configure_serial(fd, baud):
+    if baud not in BAUD_RATES:
+        raise ValueError(f"unsupported baud rate: {baud}")
+
+    attrs = termios.tcgetattr(fd)
+    attrs[0] = 0
+    attrs[1] = 0
+    attrs[2] = termios.CS8 | termios.CREAD | termios.CLOCAL
+    attrs[3] = 0
+    attrs[4] = BAUD_RATES[baud]
+    attrs[5] = BAUD_RATES[baud]
+    attrs[6][termios.VMIN] = 0
+    attrs[6][termios.VTIME] = 0
+    termios.tcsetattr(fd, termios.TCSANOW, attrs)
+    termios.tcflush(fd, termios.TCIOFLUSH)
+
+
+def open_serial(device, baud):
+    fd = os.open(device, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
+    configure_serial(fd, baud)
+    return fd
+
+
+def drain_serial(fd, seconds):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        readable, _, _ = select.select([fd], [], [], 0.05)
+        if readable:
+            try:
+                os.read(fd, 4096)
+            except BlockingIOError:
+                pass
+
+
+def start_flash(enabled):
+    if not enabled:
+        return None
+    print("Running make flash while BQ27742 capture is active...", flush=True)
+    return subprocess.Popen(["make", "flash"])
+
+
+def capture(fd, output_path, timeout, flash_process):
+    deadline = time.monotonic() + timeout
+    chunks = []
+
+    with open(output_path, "wb") as output:
+        while time.monotonic() < deadline:
+            readable, _, _ = select.select([fd], [], [], 0.1)
+            if readable:
+                try:
+                    chunk = os.read(fd, 4096)
+                except BlockingIOError:
+                    chunk = b""
+
+                if chunk:
+                    output.write(chunk)
+                    output.flush()
+                    chunks.append(chunk)
+                    text = b"".join(chunks).decode("utf-8", "replace")
+                    if "BQ27742_TEMP_TEST END" in text:
+                        return text
+
+            if flash_process is not None and flash_process.poll() is not None:
+                pass
+
+    return b"".join(chunks).decode("utf-8", "replace")
+
+
+def decode_temp(raw):
+    return (raw / 10.0) - 273.15
+
+
+def parse_results(text):
+    results = {}
+    api = None
+
+    for line in text.splitlines():
+        temp_match = TEMP_RE.search(line)
+        if temp_match:
+            name = temp_match.group("name")
+            raw = int(temp_match.group("raw"), 16)
+            results[name] = {
+                "raw": raw,
+                "lsb": int(temp_match.group("lsb"), 16),
+                "msb": int(temp_match.group("msb"), 16),
+                "c_x10": int(temp_match.group("c_x10")),
+                "c": decode_temp(raw),
+            }
+            continue
+
+        api_match = API_RE.search(line)
+        if api_match:
+            api = {
+                "api_temp_c": int(api_match.group("api")),
+                "voltage_mv": int(api_match.group("voltage")),
+                "safety": int(api_match.group("safety"), 16),
+                "flags": int(api_match.group("flags"), 16),
+            }
+
+    return results, api
+
+
+def validate(results, api):
+    errors = []
+
+    for name in ("selected_temp", "internal_temp"):
+        if name not in results:
+            errors.append(f"missing {name} diagnostic line")
+            continue
+
+        raw = results[name]["raw"]
+        temp_c = results[name]["c"]
+        if raw == 0:
+            errors.append(f"{name} raw register is 0x0000")
+        if temp_c < -40.0 or temp_c > 100.0:
+            errors.append(f"{name} decoded temperature is implausible: {temp_c:.2f} C")
+
+    if api is None:
+        errors.append("missing api_temp_c diagnostic line")
+    elif "selected_temp" in results:
+        decoded_whole_c = int(results["selected_temp"]["c"])
+        if api["api_temp_c"] != decoded_whole_c:
+            errors.append(
+                "firmware API temperature does not match selected raw register "
+                f"(api={api['api_temp_c']} C, decoded={decoded_whole_c} C)"
+            )
+
+    return errors
+
+
+def print_summary(results, api, errors, output_path, flash_process):
+    print(f"Log written to: {output_path}")
+
+    if flash_process is not None:
+        status = flash_process.poll()
+        if status is None:
+            status = flash_process.wait()
+        print(f"make flash exit code: {status}")
+
+    for name in ("selected_temp", "internal_temp"):
+        value = results.get(name)
+        if value is None:
+            print(f"{name}: not found")
+            continue
+        print(
+            f"{name}: raw=0x{value['raw']:04x} "
+            f"lsb=0x{value['lsb']:02x} msb=0x{value['msb']:02x} "
+            f"decoded={value['c']:.2f} C c_x10={value['c_x10']}"
+        )
+
+    if api is None:
+        print("api/context: not found")
+    else:
+        print(
+            f"api/context: api_temp_c={api['api_temp_c']} "
+            f"voltage_mv={api['voltage_mv']} "
+            f"safety=0x{api['safety']:02x} flags=0x{api['flags']:04x}"
+        )
+
+    if errors:
+        print("BQ27742 temperature diagnostic: FAIL")
+        for error in errors:
+            print(f"  - {error}")
+    else:
+        print("BQ27742 temperature diagnostic: PASS")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Capture and validate BQ27742 temperature diagnostic firmware logs."
+    )
+    parser.add_argument("--device", default=DEFAULT_DEVICE, help=f"serial device, default {DEFAULT_DEVICE}")
+    parser.add_argument("--baud", type=int, default=DEFAULT_BAUD, help=f"baud rate, default {DEFAULT_BAUD}")
+    parser.add_argument("--timeout", type=float, default=20.0, help="capture timeout in seconds, default 20")
+    parser.add_argument("--output", default=DEFAULT_OUTPUT, help=f"log output path, default {DEFAULT_OUTPUT}")
+    parser.add_argument("--flash", action="store_true", help="run make flash after opening serial capture")
+    parser.add_argument("--no-drain", action="store_true", help="do not discard stale bytes before capture")
+    args = parser.parse_args()
+
+    try:
+        fd = open_serial(args.device, args.baud)
+    except OSError as exc:
+        print(f"ERROR: could not open {args.device}: {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    flash_process = None
+    try:
+        if not args.no_drain:
+            drain_serial(fd, 0.25)
+        flash_process = start_flash(args.flash)
+        text = capture(fd, args.output, args.timeout, flash_process)
+    finally:
+        os.close(fd)
+
+    results, api = parse_results(text)
+    errors = validate(results, api)
+    print_summary(results, api, errors, args.output, flash_process)
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- fix BQ27742 temperature reporting so the converted Celsius value is returned instead of the cached zero value
- add an opt-in BQ27742 temperature diagnostic firmware mode that logs selected and internal temperature raw register values
- add a host capture/parser script for validating the diagnostic output while flashing test firmware

## Validation
- `tools/bq27742_temp_test.py --device /dev/ttyACM0 --flash`
  - selected/TS temperature: `27.85 C`
  - internal temperature: `26.55 C`
  - API temperature: `27 C`
  - diagnostic result: `PASS`
- Docker default firmware build: `cmake .. -DLOGGER=USB -DBQ27742_TEMP_TEST=0 && make -j2`
- Docker diagnostic firmware build: `cmake .. -DLOGGER=UART -DBQ27742_TEMP_TEST=1 && make -j2`

## Notes
The diagnostic confirms the BQ27742 TS path is working and the issue is firmware-side, not hardware.

Related: https://github.com/tekkura/sr-cad/issues/10
