### PR TITLE
Add GPIO26 ADC diagnostic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CMAKE_COLOR_MAKEFILE ON)
 # Build options
 option(USE_DOCKER "Build using Docker container" ON)
 option(USE_LOCAL "Build locally instead of Docker" OFF)
+set(GPIO26_ADC_TEST "0" CACHE STRING "Enable GPIO26 ADC diagnostic logs")
 
 # Set build type if not specified
 if(NOT CMAKE_BUILD_TYPE)
@@ -84,6 +85,10 @@ pico_enable_stdio_usb(robot 1)
 
 if(LOGGER STREQUAL "UART")
     target_compile_definitions(robot PUBLIC LOGGER_UART=1)
+endif()
+
+if(GPIO26_ADC_TEST)
+    target_compile_definitions(robot PUBLIC GPIO26_ADC_TEST=1)
 endif()
 
 # Add the standard library to the build

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ JOBS ?= $(shell nproc)
 DOCKER_DEBUG_CONTAINER := smartphone-robot-debug
 ARCH ?= amd64
 LOGGER ?= USB
+GPIO26_ADC_TEST ?= 0
 
 #  MILESTONE 1: BOARD SELECTION & VALIDATION 
 BOARD ?= customPCB
@@ -20,6 +21,9 @@ ifeq ($(BOARD),pico)
 else
     BOARD_FLAGS = 
 endif
+
+GPIO26_ADC_FLAGS = \
+	-DGPIO26_ADC_TEST=$(GPIO26_ADC_TEST)
 
 # Variable for the RTT Test to access the serial port
 DOCKER_USB_DEVICE ?= /dev/ttyACM0
@@ -63,6 +67,7 @@ help:
 	@echo "  make docker      - Build or rebuild the Docker image (must be in project root)"
 	@echo "  make shell       - Start an interactive shell in the Docker container"
 	@echo "  make benchmark   - Build and run host benchmark (in Docker)"
+	@echo "  make gpio26-adc-test-firmware - Build GPIO26 ADC diagnostic firmware"
 	@echo "  make test TEST=rtt BOARD=[pico|customPCB] - Run full RTT benchmark flow"
 	@echo ""
 	@echo "Assumptions:"
@@ -74,13 +79,18 @@ help:
 	@echo "  JOBS=N                - Number of parallel build jobs (default: The number of processor cores)"
 	@echo "  ARCH=amd64|arm64        - Specify architecture for all make targets (default: amd64)"
 	@echo "  LOGGER=USB|UART         - Specify logger interface (default: USB)"
+	@echo "  GPIO26_ADC_TEST=0|1     - Enable GPIO26 ADC diagnostic logs (default: 0)"
 	@echo "  Example: make flash DOCKER_USB_DEVICE=/dev/ttyACM0"
 
 # Build firmware
 .PHONY: firmware
 firmware:
 	@echo "Building firmware in Docker with $(JOBS) jobs..."
-	$(DOCKER_RUN) bash -c "rm -rf build && mkdir build && cd build && cmake .. -DLOGGER=$(LOGGER) $(BOARD_FLAGS) && make -j$(JOBS)"
+	$(DOCKER_RUN) bash -c "rm -rf build && mkdir build && cd build && cmake .. -DLOGGER=$(LOGGER) $(BOARD_FLAGS) $(GPIO26_ADC_FLAGS) && make -j$(JOBS)"
+
+.PHONY: gpio26-adc-test-firmware
+gpio26-adc-test-firmware:
+	$(MAKE) firmware GPIO26_ADC_TEST=1 LOGGER=UART
 
 # Name for the persistent debug container
 DEBUG_CONTAINER := smartphone-robot-debug

--- a/include/ncp3901.h
+++ b/include/ncp3901.h
@@ -9,5 +9,8 @@ bool ncp3901_wireless_charger_attached();
 uint16_t ncp3901_adc0();
 void ncp3901_shutdown();
 void test_ncp3901_interrupt();
+#ifdef GPIO26_ADC_TEST
+void ncp3901_gpio26_adc_test_run();
+#endif
 
 #endif

--- a/src/ncp3901.c
+++ b/src/ncp3901.c
@@ -4,6 +4,7 @@
 #include "ncp3901.h"
 #include "hardware/adc.h"
 #include "robot.h"
+#include <stdint.h>
 #include <inttypes.h>
 #include "custom_printf.h"
 
@@ -15,6 +16,18 @@ static int8_t _gpio_otg;
 static bool test_ncp3901_started = false;
 static bool test_ncp3901_completed = false;
 static bool wireless_charger_attached = false;
+
+#ifdef GPIO26_ADC_TEST
+#define GPIO26_ADC_TEST_SAMPLES 64
+#define GPIO26_ADC_TEST_DELAY_MS 20
+#define GPIO26_ADC_TEST_LOW_RAW_THRESHOLD 32
+#define GPIO26_ADC_TEST_ADC_REF_MV 3300
+#define GPIO26_ADC_TEST_ADC_MAX_RAW 4095
+
+static uint32_t gpio26_adc_raw_to_mv(uint16_t raw){
+    return ((uint32_t)raw * GPIO26_ADC_TEST_ADC_REF_MV) / GPIO26_ADC_TEST_ADC_MAX_RAW;
+}
+#endif
 
 // on wireless power available
 void ncp3901_on_wireless_charger_interrupt(uint gpio, uint32_t event_mask)
@@ -90,6 +103,52 @@ uint16_t ncp3901_adc0()
     // rp2040_log("Raw value: 0x%03x, voltage: %f V\n", result, result * conversion_factor);
 }
 
+#ifdef GPIO26_ADC_TEST
+void ncp3901_gpio26_adc_test_run(){
+    uint16_t min_raw = UINT16_MAX;
+    uint16_t max_raw = 0;
+    uint64_t sum_raw = 0;
+
+    rp2040_log("GPIO26_ADC_TEST START samples=%d delay_ms=%d adc_ref_mv=%d adc_max_raw=%d\n",
+        GPIO26_ADC_TEST_SAMPLES,
+        GPIO26_ADC_TEST_DELAY_MS,
+        GPIO26_ADC_TEST_ADC_REF_MV,
+        GPIO26_ADC_TEST_ADC_MAX_RAW);
+    rp2040_log("GPIO26_ADC_TEST note=ADC reports GPIO26 pin voltage only; external USB voltage may be divided before the ADC pin\n");
+
+    for (uint16_t i = 0; i < GPIO26_ADC_TEST_SAMPLES; i++){
+        uint16_t raw = ncp3901_adc0();
+        uint32_t mv = gpio26_adc_raw_to_mv(raw);
+        if (raw < min_raw){
+            min_raw = raw;
+        }
+        if (raw > max_raw){
+            max_raw = raw;
+        }
+        sum_raw += raw;
+        rp2040_log("GPIO26_ADC_TEST sample=%u raw=%u adc_mv=%u\n", i, raw, mv);
+        sleep_ms(GPIO26_ADC_TEST_DELAY_MS);
+    }
+
+    uint16_t avg_raw = (uint16_t)(sum_raw / GPIO26_ADC_TEST_SAMPLES);
+    uint32_t avg_mv = gpio26_adc_raw_to_mv(avg_raw);
+    rp2040_log("GPIO26_ADC_TEST summary min_raw=%u max_raw=%u avg_raw=%u avg_adc_mv=%u\n",
+        min_raw,
+        max_raw,
+        avg_raw,
+        avg_mv);
+
+    if (max_raw <= GPIO26_ADC_TEST_LOW_RAW_THRESHOLD){
+        rp2040_log("GPIO26_ADC_TEST result=LOW_RAW warning=max_raw_at_or_below_%d\n",
+            GPIO26_ADC_TEST_LOW_RAW_THRESHOLD);
+    } else {
+        rp2040_log("GPIO26_ADC_TEST result=ADC_ACTIVE\n");
+    }
+
+    rp2040_log("GPIO26_ADC_TEST END\n");
+}
+#endif
+
 void ncp3901_shutdown(){
 }
 
@@ -145,4 +204,3 @@ static int32_t ncp3901_test_response(){
     test_ncp3901_completed = true;
     return 0;
 }
-

--- a/src/robot.c
+++ b/src/robot.c
@@ -210,6 +210,9 @@ void on_start(){
     turn_on_leds();
     STWLC38JRM_init(WIRELESS_CHG_EN, WIRELESS_CHG_VRECT);
     ncp3901_init(GPIO_WIRELESS_AVAILABLE, GPIO_OTG);
+#ifdef GPIO26_ADC_TEST
+    ncp3901_gpio26_adc_test_run();
+#endif
     max77976_init(BATTERY_CHARGER_INTERRUPT_PIN, &call_queue, &results_queue);
     sn74ahc125rgyr_init(SN74AHC125RGYR_GPIO1);
     sn74ahc125rgyr_init(SN74AHC125RGYR_GPIO2);

--- a/tools/gpio26_adc_test.py
+++ b/tools/gpio26_adc_test.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import re
+import select
+import subprocess
+import sys
+import termios
+import time
+
+
+DEFAULT_DEVICE = "/dev/ttyACM0"
+DEFAULT_OUTPUT = "/tmp/gpio26-adc-test.log"
+DEFAULT_BAUD = 115200
+
+BAUD_RATES = {
+    9600: termios.B9600,
+    19200: termios.B19200,
+    38400: termios.B38400,
+    57600: termios.B57600,
+    115200: termios.B115200,
+}
+
+SAMPLE_RE = re.compile(
+    r"GPIO26_ADC_TEST sample=(?P<sample>\d+) "
+    r"raw=(?P<raw>\d+) adc_mv=(?P<adc_mv>\d+)"
+)
+SUMMARY_RE = re.compile(
+    r"GPIO26_ADC_TEST summary min_raw=(?P<min_raw>\d+) "
+    r"max_raw=(?P<max_raw>\d+) avg_raw=(?P<avg_raw>\d+) "
+    r"avg_adc_mv=(?P<avg_adc_mv>\d+)"
+)
+RESULT_RE = re.compile(r"GPIO26_ADC_TEST result=(?P<result>[A-Z_]+)")
+
+
+def configure_serial(fd, baud):
+    if baud not in BAUD_RATES:
+        raise ValueError(f"unsupported baud rate: {baud}")
+
+    attrs = termios.tcgetattr(fd)
+    attrs[0] = 0
+    attrs[1] = 0
+    attrs[2] = termios.CS8 | termios.CREAD | termios.CLOCAL
+    attrs[3] = 0
+    attrs[4] = BAUD_RATES[baud]
+    attrs[5] = BAUD_RATES[baud]
+    attrs[6][termios.VMIN] = 0
+    attrs[6][termios.VTIME] = 0
+    termios.tcsetattr(fd, termios.TCSANOW, attrs)
+    termios.tcflush(fd, termios.TCIOFLUSH)
+
+
+def open_serial(device, baud):
+    fd = os.open(device, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
+    configure_serial(fd, baud)
+    return fd
+
+
+def drain_serial(fd, seconds):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        readable, _, _ = select.select([fd], [], [], 0.05)
+        if readable:
+            try:
+                os.read(fd, 4096)
+            except BlockingIOError:
+                pass
+
+
+def start_flash(enabled):
+    if not enabled:
+        return None
+    print("Running make flash while GPIO26 capture is active...", flush=True)
+    return subprocess.Popen(["make", "flash"])
+
+
+def capture(fd, output_path, timeout, flash_process):
+    deadline = time.monotonic() + timeout
+    chunks = []
+
+    with open(output_path, "wb") as output:
+        while time.monotonic() < deadline:
+            readable, _, _ = select.select([fd], [], [], 0.1)
+            if readable:
+                try:
+                    chunk = os.read(fd, 4096)
+                except BlockingIOError:
+                    chunk = b""
+
+                if chunk:
+                    output.write(chunk)
+                    output.flush()
+                    chunks.append(chunk)
+                    text = b"".join(chunks).decode("utf-8", "replace")
+                    if "GPIO26_ADC_TEST END" in text:
+                        return text
+
+            if flash_process is not None and flash_process.poll() is not None:
+                pass
+
+    return b"".join(chunks).decode("utf-8", "replace")
+
+
+def parse_results(text):
+    samples = []
+    summary = None
+    result = None
+
+    for line in text.splitlines():
+        sample_match = SAMPLE_RE.search(line)
+        if sample_match:
+            samples.append({
+                "sample": int(sample_match.group("sample")),
+                "raw": int(sample_match.group("raw")),
+                "adc_mv": int(sample_match.group("adc_mv")),
+            })
+            continue
+
+        summary_match = SUMMARY_RE.search(line)
+        if summary_match:
+            summary = {
+                "min_raw": int(summary_match.group("min_raw")),
+                "max_raw": int(summary_match.group("max_raw")),
+                "avg_raw": int(summary_match.group("avg_raw")),
+                "avg_adc_mv": int(summary_match.group("avg_adc_mv")),
+            }
+            continue
+
+        result_match = RESULT_RE.search(line)
+        if result_match:
+            result = result_match.group("result")
+
+    return samples, summary, result
+
+
+def validate(samples, summary, result):
+    errors = []
+    warnings = []
+
+    if not samples:
+        errors.append("missing GPIO26 sample lines")
+    if summary is None:
+        errors.append("missing GPIO26 summary line")
+    if result is None:
+        errors.append("missing GPIO26 result line")
+
+    if summary is not None and summary["max_raw"] <= 32:
+        warnings.append(
+            "GPIO26 stayed near zero; this matches the suspicious 16-17 raw range"
+        )
+    if result == "LOW_RAW":
+        warnings.append("firmware reported LOW_RAW")
+
+    return errors, warnings
+
+
+def print_summary(samples, summary, result, errors, warnings, output_path, flash_process):
+    print(f"Log written to: {output_path}")
+
+    if flash_process is not None:
+        status = flash_process.poll()
+        if status is None:
+            status = flash_process.wait()
+        print(f"make flash exit code: {status}")
+
+    print(f"samples captured: {len(samples)}")
+    if summary is None:
+        print("summary: not found")
+    else:
+        print(
+            "summary: "
+            f"min_raw={summary['min_raw']} "
+            f"max_raw={summary['max_raw']} "
+            f"avg_raw={summary['avg_raw']} "
+            f"avg_adc_mv={summary['avg_adc_mv']}"
+        )
+
+    print(f"firmware result: {result or 'not found'}")
+
+    if errors:
+        print("GPIO26 ADC diagnostic: FAIL")
+        for error in errors:
+            print(f"  - {error}")
+        return
+
+    if warnings:
+        print("GPIO26 ADC diagnostic: WARN")
+        for warning in warnings:
+            print(f"  - {warning}")
+        return
+
+    print("GPIO26 ADC diagnostic: PASS")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Capture and summarize GPIO26 ADC diagnostic firmware logs."
+    )
+    parser.add_argument("--device", default=DEFAULT_DEVICE, help=f"serial device, default {DEFAULT_DEVICE}")
+    parser.add_argument("--baud", type=int, default=DEFAULT_BAUD, help=f"baud rate, default {DEFAULT_BAUD}")
+    parser.add_argument("--timeout", type=float, default=20.0, help="capture timeout in seconds, default 20")
+    parser.add_argument("--output", default=DEFAULT_OUTPUT, help=f"log output path, default {DEFAULT_OUTPUT}")
+    parser.add_argument("--flash", action="store_true", help="run make flash after opening serial capture")
+    parser.add_argument("--no-drain", action="store_true", help="do not discard stale bytes before capture")
+    args = parser.parse_args()
+
+    try:
+        fd = open_serial(args.device, args.baud)
+    except OSError as exc:
+        print(f"ERROR: could not open {args.device}: {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    flash_process = None
+    try:
+        if not args.no_drain:
+            drain_serial(fd, 0.25)
+        flash_process = start_flash(args.flash)
+        text = capture(fd, args.output, args.timeout, flash_process)
+    finally:
+        os.close(fd)
+
+    samples, summary, result = parse_results(text)
+    errors, warnings = validate(samples, summary, result)
+    print_summary(samples, summary, result, errors, warnings, args.output, flash_process)
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Add a GPIO26_ADC_TEST firmware mode that samples GPIO26/ADC0 after NCP3901 initialization and logs raw counts, ADC pi
n millivolts, and min/max/average values.

Wire the diagnostic through CMake and Make with a `gpio26-adc-test-firmware` target, and add a UART capture helper th
at parses the diagnostic output and flags values stuck near the previously observed raw 16-17 range.

## Summary
- In scope:
  - Adds a compile-time GPIO26 ADC diagnostic mode.
  - Samples GPIO26/ADC0 during startup after `ncp3901_init(...)`.
  - Logs raw ADC readings, ADC-pin millivolts, and min/max/average values.
  - Adds `make gpio26-adc-test-firmware`.
  - Adds `tools/gpio26_adc_test.py` to flash/capture/parse UART diagnostic output.
- Findings from the diagnostic:
  - With external USB connected, GPIO26/ADC0 still reads near zero: raw `14-17`, about `12 mV`.
  - This confirms the original concern that the ADC reading is far lower than expected for a USB-voltage sense path.
- Hardware/schematic interpretation:
  - The attached schematic routes `ADC0` into `SN74AHC125RGYR` pin 2 (`1A`) and routes pin 3 (`1Y`) to `GPIO26_ADC0`.
  - Per the SN74AHC125 datasheet, this part is a digital A-to-Y 3-state buffer, not an analog pass/protection device.
  - The RP2040 ADC is therefore connected to a digital CMOS buffer output, not directly to a proportional analog volt
age sense node.
  - A near-zero ADC value is expected if the buffer output is low, disabled/high-Z and pulled/leaking low, or if the 
upstream digital input is below the logic-high threshold.
  - Even when enabled, this chip would only drive a digital low/high output; it cannot preserve the analog voltage ne
eded for ADC measurement.
- Intentionally out of scope:
  - No hardware fix is made in this firmware PR.
  - No replacement ADC protection/switch/mux part is selected here.
  - No change is made to normal firmware behavior unless `GPIO26_ADC_TEST=1` is enabled.
- [ ] I have read and agree to follow `docs/PR_WORKFLOW.md` for this PR.

## Branching
- Milestone base branch: `milestone/[milestone-name]`
- This PR branch: `gpio26`
- [ ] Branch naming follows the required convention.
- [ ] Branch is rebased on the current base branch (no merge commit from "Update branch").

## Milestone And Guide
- [ ] Milestone tag is set on this PR.
- Migration guide used:
  - `docs/migrations/<MilestoneName>.md`

## Scope Declaration
- Exact slice/module in this PR:
  - `Makefile`
  - `CMakeLists.txt`
  - `src/ncp3901.c`
  - `include/ncp3901.h`
  - `src/robot.c`
  - `tools/gpio26_adc_test.py`
- Related sibling PRs/issues:
  - Confirms https://github.com/tekkura/sr-cad/issues/11
  - Will be solved by https://github.com/tekkura/sr-cad/issues/14
