### PR TITLE
Track populated log buffer entries

### DIFF
--- a/include/rp2040_log.h
+++ b/include/rp2040_log.h
@@ -21,6 +21,8 @@ typedef struct {
     char log_array[LOG_BUFFER_LINE_COUNT][LOG_BUFFER_CHAR_LIMIT];
     // create an array storing the variable size of each line in the log_array
     uint16_t log_array_line_size[LOG_BUFFER_LINE_COUNT];
+    // number of populated entries currently stored in the ring
+    uint16_t count;
     uint16_t head;
     uint16_t tail;
     volatile bool lock; // Added a lock variable

--- a/include/rp2040_log.h
+++ b/include/rp2040_log.h
@@ -23,6 +23,7 @@ typedef struct {
     uint16_t log_array_line_size[LOG_BUFFER_LINE_COUNT];
     // number of populated entries currently stored in the ring
     uint16_t count;
+    uint16_t byte_count;
     uint16_t head;
     uint16_t tail;
     volatile bool lock; // Added a lock variable

--- a/src/rp2040_log.c
+++ b/src/rp2040_log.c
@@ -1,4 +1,5 @@
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include "pico/mutex.h"
 #include "pico/types.h"
@@ -21,6 +22,37 @@ auto_init_mutex(rp2040_log_buffer_mutex);
 
 static bool rp2040_log_buffer_is_empty() {
     return log_buffer.count == 0;
+}
+
+static uint16_t rp2040_log_payload_size(uint16_t line_size) {
+    return line_size > 0 ? line_size - 1 : 0;
+}
+
+static void rp2040_log_drop_oldest() {
+    if (rp2040_log_buffer_is_empty()) {
+        return;
+    }
+
+    uint16_t payload_size = rp2040_log_payload_size(log_buffer.log_array_line_size[log_buffer.head]);
+    if (payload_size > log_buffer.byte_count) {
+        log_buffer.byte_count = 0;
+    } else {
+        log_buffer.byte_count -= payload_size;
+    }
+
+    log_buffer.log_array_line_size[log_buffer.head] = 0;
+    log_buffer.head = (log_buffer.head + 1) % LOG_BUFFER_LINE_COUNT;
+    log_buffer.count--;
+    if (rp2040_log_buffer_is_empty()) {
+        log_buffer.tail = log_buffer.head;
+    }
+}
+
+static void rp2040_log_make_room(uint16_t payload_size) {
+    while (log_buffer.count == LOG_BUFFER_LINE_COUNT ||
+           (uint32_t)log_buffer.byte_count + payload_size > UINT16_MAX) {
+        rp2040_log_drop_oldest();
+    }
 }
 
 // Initialize the circular buffer
@@ -76,6 +108,8 @@ void rp2040_log(int level, const char* format, ...) {
 	len = LOG_BUFFER_CHAR_LIMIT;
     }
 
+    uint16_t payload_size = rp2040_log_payload_size(len);
+    rp2040_log_make_room(payload_size);
 
     // Format the message and copy it to the buffer, handling wrapping
     va_start(args, format); // Restart the argument list
@@ -83,11 +117,8 @@ void rp2040_log(int level, const char* format, ...) {
     va_end(args);
 
     log_buffer.log_array_line_size[log_buffer.tail] = len; // store the size of the line -2 for removing \n and null terminator
-    if (log_buffer.count == LOG_BUFFER_LINE_COUNT) {
-        log_buffer.head = (log_buffer.head + 1) % LOG_BUFFER_LINE_COUNT;
-    } else {
-        log_buffer.count++;
-    }
+    log_buffer.byte_count += payload_size;
+    log_buffer.count++;
     log_buffer.tail = (log_buffer.tail + 1) % LOG_BUFFER_LINE_COUNT; // Update tail correctly
 
     rp2040_log_release_lock(); // Release the lock
@@ -95,22 +126,7 @@ void rp2040_log(int level, const char* format, ...) {
 
 // Function to retrieve the total number of bytes within the log_array
 uint16_t rp2040_get_byte_count() {
-   // Sum only populated entries within the live ring segment.
-   uint16_t byte_count = 0;
-   if (rp2040_log_buffer_is_empty()) {
-       return 0;
-   }
-
-   uint16_t index = log_buffer.head;
-   for (uint16_t i = 0; i < log_buffer.count; i++) {
-       uint16_t line_size = log_buffer.log_array_line_size[index];
-       if (line_size > 0) {
-           byte_count += line_size - 1;
-       }
-       index = (index + 1) % LOG_BUFFER_LINE_COUNT;
-   }
-
-   return byte_count;
+   return log_buffer.byte_count;
 }
 
 void rp2040_log_flush(){
@@ -132,4 +148,5 @@ void rp2040_log_flush(){
     log_buffer.head = 0;
     log_buffer.tail = 0;
     log_buffer.count = 0;
+    log_buffer.byte_count = 0;
 }

--- a/src/rp2040_log.c
+++ b/src/rp2040_log.c
@@ -19,10 +19,16 @@
 static CircularBufferLog log_buffer;
 auto_init_mutex(rp2040_log_buffer_mutex);
 
+static bool rp2040_log_buffer_is_empty() {
+    return log_buffer.count == 0;
+}
+
 // Initialize the circular buffer
 void rp2040_log_init() {
+    memset(&log_buffer, 0, sizeof(log_buffer));
     log_buffer.head = 0; 
     log_buffer.tail = 0;
+    log_buffer.count = 0;
     
     #ifdef LOGGER_UART
     // Initialize dedicated UART for logging (separate from stdio)
@@ -77,9 +83,10 @@ void rp2040_log(int level, const char* format, ...) {
     va_end(args);
 
     log_buffer.log_array_line_size[log_buffer.tail] = len; // store the size of the line -2 for removing \n and null terminator
-    // update head
-    if (log_buffer.tail == log_buffer.head) {
+    if (log_buffer.count == LOG_BUFFER_LINE_COUNT) {
         log_buffer.head = (log_buffer.head + 1) % LOG_BUFFER_LINE_COUNT;
+    } else {
+        log_buffer.count++;
     }
     log_buffer.tail = (log_buffer.tail + 1) % LOG_BUFFER_LINE_COUNT; // Update tail correctly
 
@@ -88,21 +95,41 @@ void rp2040_log(int level, const char* format, ...) {
 
 // Function to retrieve the total number of bytes within the log_array
 uint16_t rp2040_get_byte_count() {
-   // sum up the values witin log_array_line_size
-   uint16_t byte_count = 0; 
-   for (int i = 0; i < LOG_BUFFER_LINE_COUNT; i++) {
-	   if (log_buffer.log_array_line_size[i] > 0) {
-	       byte_count += log_buffer.log_array_line_size[i] - 1;
-	   }
+   // Sum only populated entries within the live ring segment.
+   uint16_t byte_count = 0;
+   if (rp2040_log_buffer_is_empty()) {
+       return 0;
    }
+
+   uint16_t index = log_buffer.head;
+   for (uint16_t i = 0; i < log_buffer.count; i++) {
+       uint16_t line_size = log_buffer.log_array_line_size[index];
+       if (line_size > 0) {
+           byte_count += line_size - 1;
+       }
+       index = (index + 1) % LOG_BUFFER_LINE_COUNT;
+   }
+
    return byte_count;
 }
 
 void rp2040_log_flush(){
-    // printf each line within the log_array starting at the head
-    for (int i = 0; i < LOG_BUFFER_LINE_COUNT; i++) {
-	// only print up to log_array_line_size
-	printf("%.*s", log_buffer.log_array_line_size[log_buffer.head], log_buffer.log_array[log_buffer.head]);
-	log_buffer.head = (log_buffer.head + 1) % LOG_BUFFER_LINE_COUNT; // Update head correctly
+    if (rp2040_log_buffer_is_empty()) {
+        return;
     }
+
+    // Print only populated entries within the live ring segment.
+    uint16_t index = log_buffer.head;
+    for (uint16_t i = 0; i < log_buffer.count; i++) {
+        uint16_t line_size = log_buffer.log_array_line_size[index];
+        if (line_size > 0) {
+            printf("%.*s", line_size, log_buffer.log_array[index]);
+        }
+        index = (index + 1) % LOG_BUFFER_LINE_COUNT;
+    }
+
+    // Drain the buffer so the next GET_LOG only reports new entries.
+    log_buffer.head = 0;
+    log_buffer.tail = 0;
+    log_buffer.count = 0;
 }


### PR DESCRIPTION
## Summary
- Track the number of populated log-buffer entries.
- Flush and count only live entries instead of iterating over the full backing array.
- Drain the buffer after flushing so later reads only include new log entries.

## Dependency
This draft PR depends on #30 (`log-levels`) merging first.

It is intentionally separated from #30 because #30 should stay scoped to adding log verbosity levels and replacing old `rp2040_log(...)` call sites with level-specific wrappers. These circular-buffer changes are related logger cleanup, but they change buffered logging behavior rather than log-level selection.

## Validation
- Reviewed the diff against `log-levels`; only `include/rp2040_log.h` and `src/rp2040_log.c` change.
- Did not run a full firmware build.
